### PR TITLE
Add Checkbox Setting

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Components\CustomCellListTableData.cs" />
     <Compile Include="Components\ScrollViewContent.cs" />
     <Compile Include="Components\Settings\BoolSetting.cs" />
+    <Compile Include="Components\Settings\CheckboxSetting.cs" />
     <Compile Include="Components\Settings\DropDownListSetting.cs" />
     <Compile Include="Components\Settings\GenericSliderSetting.cs" />
     <Compile Include="Components\Settings\IncDecSetting.cs" />
@@ -132,6 +133,7 @@
     <Compile Include="Tags\ScrollableSettingsContainerTag.cs" />
     <Compile Include="Tags\SettingsContainerTag.cs" />
     <Compile Include="Tags\Settings\BoolSettingTag.cs" />
+    <Compile Include="Tags\Settings\CheckboxSettingTag.cs" />
     <Compile Include="Tags\Settings\DropdownListSettingTag.cs" />
     <Compile Include="Tags\Settings\GenericSliderSettingTag.cs" />
     <Compile Include="Tags\Settings\IncDecSettingTag.cs" />
@@ -156,6 +158,7 @@
     <Compile Include="TypeHandlers\LeaderboardHandler.cs" />
     <Compile Include="TypeHandlers\PageButtonHandler.cs" />
     <Compile Include="TypeHandlers\RectTransformHandler.cs" />
+    <Compile Include="TypeHandlers\Settings\CheckboxSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\DropDownListSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\ListSliderSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\SettingsSubmenuHandler.cs" />

--- a/BeatSaberMarkupLanguage/Components/Settings/CheckboxSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/CheckboxSetting.cs
@@ -52,7 +52,8 @@ namespace BeatSaberMarkupLanguage.Components.Settings
 
         public void CheckboxToggled(bool value)
         {
-            ApplyValue();
+            onChange?.Invoke(checkbox.isOn);
+            if (updateOnChange) ApplyValue();
         }
 
         public void ApplyValue()

--- a/BeatSaberMarkupLanguage/Components/Settings/CheckboxSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/CheckboxSetting.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using BeatSaberMarkupLanguage.Parser;
+
+namespace BeatSaberMarkupLanguage.Components.Settings
+{
+    public class CheckboxSetting : MonoBehaviour
+    {
+        public BSMLAction onChange;
+        public BSMLValue associatedValue;
+        public bool updateOnChange = false;
+
+        public TextMeshProUGUI text;
+        public Toggle checkbox;
+
+        public bool EnableCheckbox
+        {
+            set => checkbox.interactable = value;
+        }
+
+        public bool CheckboxValue
+        {
+            set => checkbox.isOn = value;
+        }
+
+        public string Text
+        {
+            get => text.text;
+            set => text.text = value;
+        }
+
+        protected virtual void OnEnable()
+        {
+            checkbox.onValueChanged.AddListener(CheckboxToggled);
+        }
+
+        protected void OnDisable()
+        {
+            checkbox.onValueChanged.RemoveListener(CheckboxToggled);
+        }
+
+        public void Setup()
+        {
+            ReceiveValue();
+        }
+
+        public void CheckboxToggled(bool value)
+        {
+            ApplyValue();
+        }
+
+        public void ApplyValue()
+        {  //Mainly I do this so that it doesnt trigger after initially grabbing the value.
+            if (checkbox.isOn != (bool)associatedValue?.GetValue())
+                associatedValue.SetValue(checkbox.isOn);
+        }
+
+        public void ReceiveValue()
+        {
+            CheckboxValue = (bool)associatedValue?.GetValue();
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Tags/Settings/CheckboxSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/CheckboxSettingTag.cs
@@ -1,0 +1,43 @@
+﻿using BeatSaberMarkupLanguage.Components.Settings;
+using Polyglot;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Tags.Settings
+{
+    public class CheckboxSettingTag : BSMLTag
+    {
+        public override string[] Aliases => new[] { "checkbox-setting", "checkbox" };
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameplayModifierToggle baseSetting = Object.Instantiate(Resources.FindObjectsOfTypeAll<GameplayModifierToggle>().First(x => x.name == "InstaFail"), parent, false);
+            baseSetting.name = "BSMLCheckboxSetting";
+
+            GameObject gameObject = baseSetting.gameObject;
+            gameObject.SetActive(false);
+
+            Object.Destroy(baseSetting);
+            Object.Destroy(gameObject.transform.GetChild(0).gameObject); //Remove icon
+            Object.Destroy(gameObject.GetComponent<SignalOnUIToggleValueChanged>()); //Remove base game signal
+            Object.Destroy(gameObject.GetComponent<HoverHint>()); //When parsing, "RectTransform" will already add a new one. No need for this.
+            CheckboxSetting checkboxSetting = gameObject.AddComponent<CheckboxSetting>();
+            checkboxSetting.checkbox = gameObject.GetComponent<Toggle>();
+            checkboxSetting.text = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+            checkboxSetting.text.fontSize = 5; //Change some settings to conform more to the List Dropdown/IncDec settings controllers
+            checkboxSetting.text.rectTransform.localPosition = Vector2.zero;
+            checkboxSetting.text.rectTransform.anchoredPosition = Vector2.zero;
+            checkboxSetting.text.rectTransform.sizeDelta = Vector2.zero;
+
+            LayoutElement layout = gameObject.GetComponent<LayoutElement>(); //If Beat Games decides to add one later down the road.
+            if (layout is null) layout = gameObject.AddComponent<LayoutElement>(); //For the time being, they dont have one, so time to add one myself!
+            layout.preferredWidth = 90; //Again, to conform to List Dropdown/IncDec settings controllers
+            layout.preferredHeight = 8;
+
+            gameObject.SetActive(true);
+            return gameObject;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/Settings/CheckboxSettingHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/Settings/CheckboxSettingHandler.cs
@@ -1,0 +1,57 @@
+﻿using BeatSaberMarkupLanguage.Components.Settings;
+using BeatSaberMarkupLanguage.Parser;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers.Settings
+{
+    [ComponentHandler(typeof(CheckboxSetting))]
+    public class CheckboxSettingHandler : TypeHandler
+    {
+        public override Dictionary<string, string[]> Props => new Dictionary<string, string[]>()
+        {
+            { "text", new[]{ "text" } },
+            { "onChange", new[]{ "on-change" } },
+            { "value", new[]{ "value" } },
+            { "initialValue", new[]{ "initial-value" } },
+            { "setEvent", new[]{ "set-event"} },
+            { "getEvent", new[]{ "get-event"} },
+            { "applyOnChange", new[] { "apply-on-change" } }
+        };
+
+        public override void HandleType(Component obj, Dictionary<string, string> data, BSMLParserParams parserParams)
+        {
+            CheckboxSetting checkboxSetting = obj as CheckboxSetting;
+            if (data.TryGetValue("text", out string text))
+                checkboxSetting.Text = text;
+
+            if (data.TryGetValue("applyOnChange", out string applyOnChange))
+                checkboxSetting.updateOnChange = Parse.Bool(applyOnChange);
+
+            if (data.TryGetValue("initialValue", out string initialValue))
+                checkboxSetting.Text = initialValue;
+
+            if (data.TryGetValue("onChange", out string onChange))
+            {
+                if (!parserParams.actions.TryGetValue(onChange, out BSMLAction onChangeAction))
+                    throw new Exception("on-change action '" + onChange + "' not found");
+
+                checkboxSetting.onChange = onChangeAction;
+            }
+
+            if (data.TryGetValue("value", out string value))
+            {
+                if (!parserParams.values.TryGetValue(value, out BSMLValue associatedValue))
+                    throw new Exception("value '" + value + "' not found");
+
+                checkboxSetting.associatedValue = associatedValue;
+            }
+
+            parserParams.AddEvent(data.TryGetValue("setEvent", out string setEvent) ? setEvent : "apply", checkboxSetting.ApplyValue);
+            parserParams.AddEvent(data.TryGetValue("getEvent", out string getEvent) ? getEvent : "cancel", checkboxSetting.ReceiveValue);
+
+            checkboxSetting.Setup();
+        }
+    }
+}


### PR DESCRIPTION
# Why
When designing the new Counters+ settings edit screen powered by BSML, I wasn't a fan of using the IncDecSettingsController for a simple on/off option. And so, I took a checkbox from Gameplay Modifiers, spruced it up a little, and yeeted it into BSML.

Mainly, it's just for aesthetic purposes, however its hitbox extends to the entirety of the container, so clicking on it in VR would be easier. 

# Some Images
### Before
![Before](https://cdn.discordapp.com/attachments/441819897941458944/634234070355935272/unknown.png)

### After
![After](https://cdn.discordapp.com/attachments/441819897941458944/634554815975915520/unknown.png)

# Usage
```<checkbox-setting></checkbox-setting>```
Using `<checkbox>` should also work.

Tags and what not are an exact mirror copy of `BoolSetting`, so migrating from that to `CheckboxSetting` is as simple as renaming the tag in the BSML file.