### PR TITLE
allow increment settings with isInt to take an int param for on-change action

### DIFF
--- a/BeatSaberMarkupLanguage/Components/Settings/IncrementSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/IncrementSetting.cs
@@ -57,7 +57,10 @@ namespace BeatSaberMarkupLanguage.Components.Settings
         private void EitherPressed()
         {
             UpdateState();
-            onChange?.Invoke(Value);
+            if (isInt)
+                onChange?.Invoke(Convert.ToInt32(Value));
+            else
+                onChange?.Invoke(Value);
             if (updateOnChange)
                 ApplyValue();
         }


### PR DESCRIPTION
Quick change to allow this:

> [UIAction("increment-example-changed")]
> private void IncrementExampleChanged(int value)
> { Logger.log.Notice($"Integer value changed to '{value}'"); }

Instead of having a mod dev to always do a conversion themselves like this:
> [UIAction("increment-example-changed")]
> private void IncrementExampleChanged(float value)
> { Logger.log.Notice($"Integer value changed to '{Convert.ToInt32(value)}'"); }



Otherwise, this happens with the first code example:
> [CRITICAL @ 01:22:25 | UnityEngine] ArgumentException: Object of type 'System.Single' cannot be converted to type 'System.Int32'.
> [CRITICAL @ 01:22:25 | UnityEngine] System.RuntimeType.CheckValue (System.Object value, System.Reflection.Binder binder, System.Globalization.CultureInfo culture, System.Reflection.BindingFlags invokeAttr) (at <df7127ba07dc446d9f5831a0ec7b1d63>:0)
> [CRITICAL @ 01:22:25 | UnityEngine] System.Reflection.MonoMethod.ConvertValues (System.Reflection.Binder binder, System.Object[] args, System.Reflection.ParameterInfo[] pinfo, System.Globalization.CultureInfo culture, System.Reflection.BindingFlags invokeAttr) (at <df7127ba07dc446d9f5831a0ec7b1d63>:0)
> [CRITICAL @ 01:22:25 | UnityEngine] System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <df7127ba07dc446d9f5831a0ec7b1d63>:0)
> [CRITICAL @ 01:22:25 | UnityEngine] System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <df7127ba07dc446d9f5831a0ec7b1d63>:0)
> [CRITICAL @ 01:22:25 | UnityEngine] BeatSaberMarkupLanguage.Parser.BSMLAction.Invoke (System.Object[] parameters) (at <7118527913e645a7b2e212e6df43132a>:0)
> [CRITICAL @ 01:22:25 | UnityEngine] BeatSaberMarkupLanguage.Components.Settings.IncrementSetting.EitherPressed () (at <7118527913e645a7b2e212e6df43132a>:0)