### PR TITLE
Fix for broken pause menu input when LIV is connected before mods are loaded.

### DIFF
--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
@@ -94,7 +94,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
 
             SetMainCameraToCanvas setCamera = screen.GetComponent<SetMainCameraToCanvas>();
             setCamera.SetPrivateField("_canvas", canvas);
-            setCamera.SetPrivateField("_mainCamera", Resources.FindObjectsOfTypeAll<MainCamera>().FirstOrDefault());
+            setCamera.SetPrivateField("_mainCamera", Resources.FindObjectsOfTypeAll<MainCamera>().First(camera => camera.camera.stereoTargetEye != StereoTargetEyeMask.None));
 
             screen.ScreenSize = screenSize;
             screen.transform.localScale = new Vector3(0.02f, 0.02f, 0.02f);

--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
@@ -94,7 +94,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
 
             SetMainCameraToCanvas setCamera = screen.GetComponent<SetMainCameraToCanvas>();
             setCamera.SetPrivateField("_canvas", canvas);
-            setCamera.SetPrivateField("_mainCamera", Resources.FindObjectsOfTypeAll<MainCamera>().First(camera => camera.camera.stereoTargetEye != StereoTargetEyeMask.None));
+            setCamera.SetPrivateField("_mainCamera", Resources.FindObjectsOfTypeAll<MainCamera>().FirstOrDefault(camera => camera.camera.stereoTargetEye != StereoTargetEyeMask.None));
 
             screen.ScreenSize = screenSize;
             screen.transform.localScale = new Vector3(0.02f, 0.02f, 0.02f);


### PR DESCRIPTION
Fix FloatingScreen being added to the incorrect camera if the HMD was not the "first" one. Fixes broken pause menu input when LIV is connected before mods using FloatingScreen are loaded.