### PR TITLE
Fixes float UIValue being dependent on locale

### DIFF
--- a/BeatSaberMarkupLanguage/BSMLParser.cs
+++ b/BeatSaberMarkupLanguage/BSMLParser.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
+using System.Globalization;
 using UnityEngine;
 
 namespace BeatSaberMarkupLanguage
@@ -262,7 +263,17 @@ namespace BeatSaberMarkupLanguage
                             string valueID = value.Substring(1);
                             if (!parserParams.values.TryGetValue(valueID, out BSMLValue uiValue))
                                 throw new Exception("No UIValue exists with the id '" + valueID + "'");
-                            parameters.Add(propertyAliases.Key, uiValue.GetValue()?.ToString());
+
+                            object rawValue = uiValue.GetValue();
+                            string stringifiedValue;
+                            if (rawValue is float floatValue)
+                                stringifiedValue = floatValue.ToString(CultureInfo.InvariantCulture);
+                            else if (rawValue is double doubleValue)
+                                stringifiedValue = doubleValue.ToString(CultureInfo.InvariantCulture);
+                            else
+                                stringifiedValue = rawValue?.ToString();
+
+                            parameters.Add(propertyAliases.Key, stringifiedValue);
                             if (isNotifyHost && uiValue is BSMLPropertyValue propVal)
                                 if (propVal != null)
                                     propertyMap.Add(propertyAliases.Key, propVal);


### PR DESCRIPTION
I got sent [an issue earlier this week](https://github.com/chrislee0419/EnhancedSearchAndFilters/issues/9) where the increment value for an IncrementSetting component was increasing/decreasing the shown value by 25 instead of 0.25. Turns out that, when retrieving a float from UIValue, the ToString operation was locale-dependent.

In addition to floats, I've also added the same check and conversion for doubles, although that might be unnecessary, since BSML seems to never use doubles.


The relevant code from my side:
`[UIValue("inc-value")]`
`private const float IncrementValue = 0.25f;`

And its associated BSML:
`<increment-setting id="min-increment-setting"`
`  active="false"`
`  text="        Minimum Star Rating"`
`  [...]`
`  increment="~inc-value"`
`  [...]`
`  />`