### PR TITLE
Add scrolling text component and tag

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Components\ModalKeyboard.cs" />
     <Compile Include="Components\NotifiableSingleton.cs" />
     <Compile Include="Components\NotifyUpdater.cs" />
+    <Compile Include="Components\ScrollingText.cs" />
     <Compile Include="Components\ScrollViewContent.cs" />
     <Compile Include="Components\Settings\ToggleSetting.cs" />
     <Compile Include="Components\Settings\BoolSetting.cs" />
@@ -218,6 +219,7 @@
     <Compile Include="Tags\BackgroundTag.cs" />
     <Compile Include="Tags\BigButtonTag.cs" />
     <Compile Include="Tags\BSMLTag.cs" />
+    <Compile Include="Tags\ScrollingTextTag.cs" />
     <Compile Include="Tags\Settings\ToggleSettingTag.cs" />
     <Compile Include="Tags\ButtonTag.cs" />
     <Compile Include="Tags\ClickableImageTag.cs" />
@@ -265,6 +267,7 @@
     <Compile Include="TypeHandlers\BackgroundableHandler.cs" />
     <Compile Include="TypeHandlers\ButtonArtworkHandler.cs" />
     <Compile Include="TypeHandlers\GenericInteractableSettingHandler.cs" />
+    <Compile Include="TypeHandlers\ScrollingTextHandler.cs" />
     <Compile Include="TypeHandlers\SelectableHandler.cs" />
     <Compile Include="TypeHandlers\ButtonHandler.cs" />
     <Compile Include="TypeHandlers\ButtonIconHandler.cs" />

--- a/BeatSaberMarkupLanguage/Components/ScrollingText.cs
+++ b/BeatSaberMarkupLanguage/Components/ScrollingText.cs
@@ -120,6 +120,11 @@ namespace BeatSaberMarkupLanguage.Components
             rt.pivot = new Vector2(0.5f, 0.5f);
             rt.sizeDelta = Vector2.zero;
 
+            // the text object can be hit by the raycast, even when it is masked off
+            // i'm guessing it has something to do with how the text is now curved
+            // in any case, disallow the text to be a raycast target so it doesn't cover other UI elements
+            textComponent.raycastTarget = false;
+
             // allow animation to restart when text has changed
             textComponent.RegisterDirtyLayoutCallback(OnTextComponentDirtyLayout);
         }

--- a/BeatSaberMarkupLanguage/Components/ScrollingText.cs
+++ b/BeatSaberMarkupLanguage/Components/ScrollingText.cs
@@ -1,0 +1,408 @@
+﻿using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    [RequireComponent(typeof(RectTransform), typeof(RectMask2D))]
+    public class ScrollingText : MonoBehaviour
+    {
+        public RectTransform rectTransform { get; private set; }
+        public TextMeshProUGUI textComponent { get; private set; }
+
+        private string _cachedText = "";
+
+        public ScrollMovementType movementType { get; set; } = ScrollMovementType.ByDuration;
+        private ScrollAnimationType _animationType = ScrollAnimationType.Basic;
+        public ScrollAnimationType animationType
+        {
+            get => _animationType;
+            set
+            {
+                if (_animationType == value)
+                    return;
+
+                _animationType = value;
+
+                if (_scrollAnimationCoroutine != null)
+                {
+                    StopCoroutine(_scrollAnimationCoroutine);
+                    StartAnimation();
+                }
+            }
+        }
+        private float _textWidthRatioThreshold = 1.2f;
+        /// <summary>
+        /// The minimum ratio of text width to container width before scrolling occurs.
+        /// Otherwise, if the text is wider than the container, the text will be scaled down to fit the container.
+        /// </summary>
+        public float textWidthRatioThreshold
+        {
+            get => _textWidthRatioThreshold;
+            set
+            {
+                if (_textWidthRatioThreshold == value || value < 1f)
+                    return;
+
+                _textWidthRatioThreshold = value;
+            }
+        }
+        private WaitForSeconds _pauseDuration = new WaitForSeconds(2f);
+        /// <summary>
+        /// The number of seconds to wait before the scrolling animation starts and ends.
+        /// </summary>
+        public float pauseDuration
+        {
+            set
+            {
+                if (value > 0f)
+                    _pauseDuration = new WaitForSeconds(value);
+            }
+        }
+        private float _scrollDuration = 2f;
+        /// <summary>
+        /// The number of seconds it takes to scroll the text.
+        /// </summary>
+        public float scrollDuration
+        {
+            get => _scrollDuration;
+            set
+            {
+                if (value > 0f)
+                    _scrollDuration = value;
+            }
+        }
+        private float _scrollSpeed = 20f;
+        /// <summary>
+        /// The speed at which the text scrolls in units per second.
+        /// </summary>
+        public float scrollSpeed
+        {
+            get => _scrollSpeed;
+            set
+            {
+                if (value > 0f)
+                    _scrollSpeed = value;
+            }
+        }
+        public bool alwaysScroll { get; set; } = false;
+
+        private float _cachedTextWidth = 0f;
+        private float TextWidth
+        {
+            get
+            {
+                if (_cachedText != textComponent.text)
+                {
+                    _cachedTextWidth = textComponent.GetPreferredValues().x;
+                    _cachedText = textComponent.text;
+                }
+
+                return _cachedTextWidth;
+            }
+        }
+        private float TextWidthRatio => rectTransform.rect.width != 0f ? TextWidth / rectTransform.rect.width : 0f;
+
+        private IEnumerator _scrollAnimationCoroutine;
+
+        private const float ScalingMinimumSizeRatio = 0.98f;
+        private const float FadeDurationSeconds = 0.6f;
+
+        private void Awake()
+        {
+            rectTransform = GetComponent<RectTransform>();
+
+            textComponent = BeatSaberUI.CreateText(rectTransform, "", Vector2.zero);
+            var rt = textComponent.rectTransform;
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = Vector2.zero;
+
+            // allow animation to restart when text has changed
+            textComponent.RegisterDirtyLayoutCallback(OnTextComponentDirtyLayout);
+        }
+
+        private void OnEnable()
+        {
+            RecalculateElements(true);
+        }
+
+        private void OnDisable()
+        {
+            if (_scrollAnimationCoroutine != null)
+            {
+                StopCoroutine(_scrollAnimationCoroutine);
+                _scrollAnimationCoroutine = null;
+            }
+        }
+
+        private void OnTextComponentDirtyLayout()
+        {
+            if (textComponent.text != _cachedText)
+                StartCoroutine(DelayedRecalculateElements());
+        }
+
+        private void OnRectTransformDimensionsChange()
+        {
+            RecalculateElements(true);
+        }
+
+        private void RecalculateElements(bool force = false)
+        {
+            // do not reset the animation if the text has not changed
+            // _cachedText will be set when accessing TextWidth
+            if (textComponent.text == _cachedText && !force)
+                return;
+
+            if (_scrollAnimationCoroutine != null)
+            {
+                StopCoroutine(_scrollAnimationCoroutine);
+                _scrollAnimationCoroutine = null;
+            }
+
+            var rt = textComponent.rectTransform;
+            rt.anchoredPosition = Vector2.zero;
+            if (TextWidthRatio >= _textWidthRatioThreshold || alwaysScroll)
+            {
+                // resize the text component's RectTransform to take on the width of the text
+                // otherwise, if the text is too long, it will disappear
+                rt.anchorMin = new Vector2(0.5f, 0f);
+                rt.anchorMax = new Vector2(0.5f, 1f);
+                rt.sizeDelta = new Vector2(TextWidth, 0f);
+
+                // position is set in the start of the animation
+                StartAnimation();
+            }
+            else
+            {
+                // if we're changing the text here, this function will fire once again,
+                // but that should be fine
+                if (TextWidthRatio > ScalingMinimumSizeRatio)
+                {
+                    string scaleString = ((int)(100 * (ScalingMinimumSizeRatio + 0.001f) / TextWidthRatio)).InvariantToString("N0");
+                    textComponent.text = $"<size={scaleString}%>" + textComponent.text + "</size>";
+                }
+
+                rt.anchorMin = Vector2.zero;
+                rt.anchorMax = Vector2.one;
+                rt.sizeDelta = Vector2.zero;
+                rt.anchoredPosition = Vector2.zero;
+            }
+        }
+
+        private IEnumerator DelayedRecalculateElements(bool force = false)
+        {
+            yield return null;
+            RecalculateElements(force);
+        }
+
+        private void StartAnimation()
+        {
+            if (animationType == ScrollAnimationType.FadeInOut)
+                _scrollAnimationCoroutine = FadeScrollAnimationCoroutine();
+            else if (animationType == ScrollAnimationType.ForwardAndReverse)
+                _scrollAnimationCoroutine = ForwardReverseScrollAnimationCoroutine();
+            else if (animationType == ScrollAnimationType.Continuous)
+                _scrollAnimationCoroutine = ContinuousScrollAnimationCoroutine();
+            else
+                _scrollAnimationCoroutine = BasicScrollAnimationCoroutine();
+
+            StartCoroutine(_scrollAnimationCoroutine);
+        }
+
+        #region Animation Coroutines
+        private IEnumerator ScrollAnimationCoroutine(Vector2 startPos, Vector2 endPos)
+        {
+            RectTransform rt = textComponent.rectTransform;
+
+            if (movementType == ScrollMovementType.ByDuration)
+            {
+                Vector2 nextPos = startPos;
+                float seconds = 0f;
+
+                if (startPos.x > endPos.x)
+                {
+                    // left to right
+                    while (nextPos.x > endPos.x)
+                    {
+                        nextPos.x = Mathf.Lerp(startPos.x, endPos.x, seconds / scrollDuration);
+                        rt.anchoredPosition = nextPos;
+                        seconds += Time.deltaTime;
+                        yield return null;
+                    }
+                }
+                else
+                {
+                    // right to left
+                    while (nextPos.x < endPos.x)
+                    {
+                        nextPos.x = Mathf.Lerp(startPos.x, endPos.x, seconds / scrollDuration);
+                        rt.anchoredPosition = nextPos;
+                        seconds += Time.deltaTime;
+                        yield return null;
+                    }
+                }
+            }
+            else if (movementType == ScrollMovementType.BySpeed)
+            {
+                Vector2 nextPos = startPos;
+                if (startPos.x > endPos.x)
+                {
+                    // left to right
+                    nextPos.x -= Time.deltaTime * scrollSpeed;
+                    while (nextPos.x > endPos.x)
+                    {
+                        rt.anchoredPosition = nextPos;
+                        yield return null;
+                        nextPos.x -= Time.deltaTime * scrollSpeed;
+                    }
+                }
+                else
+                {
+                    // right to left
+                    nextPos.x += Time.deltaTime * scrollSpeed;
+                    while (nextPos.x < endPos.x)
+                    {
+                        rt.anchoredPosition = nextPos;
+                        yield return null;
+                        nextPos.x += Time.deltaTime * scrollSpeed;
+                    }
+                }
+            }
+        }
+
+        private IEnumerator BasicScrollAnimationCoroutine()
+        {
+            RectTransform rt = this.textComponent.rectTransform;
+            float halfTextWidth = TextWidth / 2f;
+            float halfWidth = rectTransform.rect.width / 2f;
+            Vector2 startPos = new Vector2(halfTextWidth - halfWidth, 0f);
+            Vector2 endPos = new Vector2(halfWidth - halfTextWidth, 0f);
+
+            while (true)
+            {
+                rt.anchoredPosition = startPos;
+                yield return _pauseDuration;
+
+                IEnumerator anim = ScrollAnimationCoroutine(startPos, endPos);
+                while (anim.MoveNext())
+                    yield return anim.Current;
+
+                rt.anchoredPosition = endPos;
+                yield return _pauseDuration;
+            }
+        }
+
+        private IEnumerator FadeScrollAnimationCoroutine()
+        {
+            RectTransform rt = this.textComponent.rectTransform;
+            float halfTextWidth = TextWidth / 2f;
+            float halfWidth = rectTransform.rect.width / 2f;
+            Vector2 startPos = new Vector2(halfTextWidth - halfWidth, 0f);
+            Vector2 endPos = new Vector2(halfWidth - halfTextWidth, 0f);
+
+            while (true)
+            {
+                rt.anchoredPosition = startPos;
+
+                // fade in
+                float seconds = 0f;
+                while (seconds < FadeDurationSeconds)
+                {
+                    yield return null;
+
+                    Color currentColor = textComponent.color;
+                    currentColor.a = Mathf.Lerp(0f, 1f, seconds / FadeDurationSeconds);
+                    textComponent.color = currentColor;
+
+                    seconds += Time.deltaTime;
+                }
+                yield return _pauseDuration;
+
+                IEnumerator anim = ScrollAnimationCoroutine(startPos, endPos);
+                while (anim.MoveNext())
+                    yield return anim.Current;
+
+                rt.anchoredPosition = endPos;
+                yield return _pauseDuration;
+
+                // fade out
+                seconds = 0f;
+                while (seconds < FadeDurationSeconds)
+                {
+                    Color currentColor = textComponent.color;
+                    currentColor.a = Mathf.Lerp(1f, 0f, seconds / FadeDurationSeconds);
+                    textComponent.color = currentColor;
+
+                    seconds += Time.deltaTime;
+                    yield return null;
+                }
+            }
+        }
+
+        private IEnumerator ForwardReverseScrollAnimationCoroutine()
+        {
+            RectTransform rt = this.textComponent.rectTransform;
+            float halfTextWidth = TextWidth / 2f;
+            float halfWidth = rectTransform.rect.width / 2f;
+            Vector2 startPos = new Vector2(halfTextWidth - halfWidth, 0f);
+            Vector2 endPos = new Vector2(halfWidth - halfTextWidth, 0f);
+
+            while (true)
+            {
+                rt.anchoredPosition = startPos;
+                yield return _pauseDuration;
+
+                IEnumerator anim = ScrollAnimationCoroutine(startPos, endPos);
+                while (anim.MoveNext())
+                    yield return anim.Current;
+
+                rt.anchoredPosition = endPos;
+                yield return _pauseDuration;
+
+                anim = ScrollAnimationCoroutine(endPos, startPos);
+                while (anim.MoveNext())
+                    yield return anim.Current;
+            }
+        }
+
+        private IEnumerator ContinuousScrollAnimationCoroutine()
+        {
+            RectTransform rt = this.textComponent.rectTransform;
+            float halfTextWidth = TextWidth / 2f;
+            float halfWidth = rectTransform.rect.width / 2f;
+            Vector2 startPos = new Vector2(halfTextWidth + halfWidth, 0f);
+            Vector2 endPos = new Vector2(-halfTextWidth - halfWidth, 0f);
+
+            while (true)
+            {
+                rt.anchoredPosition = startPos;
+                yield return null;
+
+                IEnumerator anim = ScrollAnimationCoroutine(startPos, endPos);
+                while (anim.MoveNext())
+                    yield return anim.Current;
+
+                rt.anchoredPosition = endPos;
+                yield return null;
+            }
+        }
+        #endregion
+
+        public enum ScrollMovementType
+        {
+            ByDuration,
+            BySpeed
+        }
+
+        public enum ScrollAnimationType
+        {
+            Basic,
+            FadeInOut,
+            ForwardAndReverse,
+            Continuous
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Parse.cs
+++ b/BeatSaberMarkupLanguage/Parse.cs
@@ -53,5 +53,10 @@ namespace BeatSaberMarkupLanguage
             else
                 return obj.ToString();
         }
+
+        public static string InvariantToString(this IFormattable obj, string format)
+        {
+            return obj.ToString(format, CultureInfo.InvariantCulture);
+        }
     }
 }

--- a/BeatSaberMarkupLanguage/Tags/ScrollingTextTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollingTextTag.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using BeatSaberMarkupLanguage.Components;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class ScrollingTextTag : BSMLTag
+    {
+        public override string[] Aliases => new[] { "scrolling-text" };
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameObject gameObject = new GameObject("BSMLScrollingText");
+            gameObject.transform.SetParent(parent, false);
+
+            ScrollingText scrollingText = gameObject.AddComponent<ScrollingText>();
+            scrollingText.rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
+            scrollingText.rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
+            scrollingText.rectTransform.sizeDelta = new Vector2(90f, 6f);
+            scrollingText.textComponent.text = "Default Text";
+            scrollingText.textComponent.fontSize = 3f;
+            scrollingText.textComponent.color = Color.white;
+
+            LayoutElement layoutElement = gameObject.AddComponent<LayoutElement>();
+            layoutElement.preferredHeight = 6f;
+            layoutElement.preferredWidth = 90f;
+
+            ExternalComponents externalComponents = gameObject.AddComponent<ExternalComponents>();
+            externalComponents.components.Add(scrollingText.textComponent);
+
+            return gameObject;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollingTextHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollingTextHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using BeatSaberMarkupLanguage.Components;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(ScrollingText))]
+    public class ScrollingTextHandler : TypeHandler<ScrollingText>
+    {
+        public override Dictionary<string, string[]> Props => new Dictionary<string, string[]>()
+        {
+            { "movementType", new[]{ "movement-type" } },
+            { "animationType", new[]{ "animation-type" } },
+            { "textWidthRatioThreshold", new[]{ "text-width-ratio-threshold" } },
+            { "pauseDuration", new[]{ "pause-duration" } },
+            { "scrollDuration", new[]{ "scroll-duration" } },
+            { "scrollSpeed", new[]{ "scroll-speed" } },
+            { "alwaysScroll", new[]{ "always-scroll" } },
+        };
+
+        public override Dictionary<string, Action<ScrollingText, string>> Setters => new Dictionary<string, Action<ScrollingText, string>>()
+        {
+            { "movementType", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.movementType = (ScrollingText.ScrollMovementType)Enum.Parse(typeof(ScrollingText.ScrollMovementType), value)) },
+            { "animationType", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.animationType = (ScrollingText.ScrollAnimationType)Enum.Parse(typeof(ScrollingText.ScrollAnimationType), value)) },
+            { "textWidthRatioThreshold", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.textWidthRatioThreshold = Parse.Float(value)) },
+            { "pauseDuration", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.pauseDuration = Parse.Float(value)) },
+            { "scrollDuration", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.scrollDuration = Parse.Float(value)) },
+            { "scrollSpeed", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.scrollSpeed = Parse.Float(value)) },
+            { "alwaysScroll", new Action<ScrollingText, string>((scrollingText, value) => scrollingText.alwaysScroll = Parse.Bool(value)) },
+        };
+    }
+}

--- a/BeatSaberMarkupLanguage/ViewControllers/TestViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/TestViewController.cs
@@ -77,6 +77,62 @@ namespace BeatSaberMarkupLanguage.ViewControllers
             }
         }
 
+        private string _changeableText = "this is a changeable text example that should serve as a testing ground for trying to see what happens when you change the text while the scrolling animation is playing";
+        [UIValue("changeable-text")]
+        public string ChangeableText
+        {
+            get => _changeableText;
+            set
+            {
+                _changeableText = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private bool _alwaysScroll = false;
+        [UIValue("always-scroll")]
+        public bool AlwaysScroll
+        {
+            get => _alwaysScroll;
+            set
+            {
+                _alwaysScroll = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private float _pauseDuration = 4f;
+        [UIValue("pause-duration")]
+        public float PauseDuration
+        {
+            get => _pauseDuration;
+            set
+            {
+                _pauseDuration = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private ScrollingText.ScrollAnimationType _animationType = ScrollingText.ScrollAnimationType.ForwardAndReverse;
+        [UIValue("animation-type")]
+        public ScrollingText.ScrollAnimationType AnimationType
+        {
+            get => _animationType;
+            set
+            {
+                _animationType = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private float _scrollSpeed = 15f;
+        [UIValue("scroll-speed")]
+        public float ScrollSpeed
+        {
+            get => _scrollSpeed;
+            set
+            {
+                _scrollSpeed = value;
+                NotifyPropertyChanged();
+            }
+        }
+
 
         [UIAction("click")]
         private void ButtonPress()
@@ -107,6 +163,54 @@ namespace BeatSaberMarkupLanguage.ViewControllers
 
             tableData.data = test;
             tableData.tableView.ReloadData();
+        }
+
+        [UIAction("text-1-button-clicked")]
+        private void ScrollingTextText1ButtonClicked()
+        {
+            AlwaysScroll = false;
+            ChangeableText = "short text example, stop animation";
+        }
+
+        [UIAction("text-2-button-clicked")]
+        private void ScrollingTextText2ButtonClicked()
+        {
+            AlwaysScroll = false;
+            ChangeableText = "this is a long text example that should cause the scrolling animation to play again. if it doesn't start the scrolling animation again, then something is wrong with the code";
+        }
+
+        [UIAction("text-3-button-clicked")]
+        private void ScrollingTextText3ButtonClicked()
+        {
+            AlwaysScroll = true;
+            ChangeableText = "short always scroll text example";
+        }
+
+        [UIAction("pause-duration-button-clicked")]
+        private void ScrollingTextPauseDurationButtonClicked()
+        {
+            if (PauseDuration < 4f)
+                PauseDuration = 4f;
+            else
+                PauseDuration = 1f;
+        }
+
+        [UIAction("animation-type-button-clicked")]
+        private void ScrollingTextAnimationTypeButtonClicked()
+        {
+            if (AnimationType == ScrollingText.ScrollAnimationType.ForwardAndReverse)
+                AnimationType = ScrollingText.ScrollAnimationType.Continuous;
+            else
+                AnimationType = ScrollingText.ScrollAnimationType.ForwardAndReverse;
+        }
+
+        [UIAction("scroll-speed-button-clicked")]
+        private void ScrollingTextScrollSpeedButtonClicked()
+        {
+            if (ScrollSpeed < 15f)
+                ScrollSpeed = 15f;
+            else
+                ScrollSpeed = 5f;
         }
     }
     public class TestListObject

--- a/BeatSaberMarkupLanguage/Views/test.bsml
+++ b/BeatSaberMarkupLanguage/Views/test.bsml
@@ -1,7 +1,7 @@
 <bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
   <macro.define id='button-text' value='Macro defined button text'></macro.define>
   <tab-selector tab-tag='new-tab'></tab-selector>
-  <tab tags='new-tab' tab-name='ScrollView test'>
+  <tab tags='new-tab' tab-name='ScrollView'>
     <vertical vertical-fit='PreferredSize' pref-height='60' pref-width='80'>
       <text text='ScrollView test' />
       <scroll-view spacing='0' pref-height='50'>
@@ -125,5 +125,82 @@
   </tab>
   <tab tags='new-tab' tab-name='text page'>
     <text-page text='~lorem-ipsum'/>
+  </tab>
+  <tab tags='new-tab' tab-name='ScrollingText'>
+    <horizontal>
+      <vertical preferred-width="60">
+        <button text="text 1" on-click="text-1-button-clicked" preferred-width="40" preferred-height="9" />
+        <button text="text 2" on-click="text-2-button-clicked" preferred-width="40" preferred-height="9" />
+        <button text="text 3" on-click="text-3-button-clicked" preferred-width="40" preferred-height="9" />
+        <button text="pause duration" on-click="pause-duration-button-clicked" preferred-width="40" preferred-height="9" />
+        <button text="animation" on-click="animation-type-button-clicked" preferred-width="40" preferred-height="9" />
+        <button text="scroll speed" on-click="scroll-speed-button-clicked" preferred-width="40" preferred-height="9" />
+      </vertical>
+      <vertical preferred-width="90">
+        <!-- short text examples -->
+        <scrolling-text text='left text example'
+                        alignment='Left'
+                        font-size='3' />
+        <scrolling-text text='center text example'
+                        alignment='Center'
+                        font-size='3' />
+        <scrolling-text text='right short example'
+                        alignment='Right'
+                        font-size='3' />
+        <scrolling-text text='always scroll short basic example'
+                        font-size='3'
+                        always-scroll='true' />
+        <scrolling-text text='always scroll short fade example'
+                        font-size='3'
+                        always-scroll='true'
+                        animation-type='FadeInOut' />
+        <scrolling-text text='always scroll short reverse example'
+                        font-size='3'
+                        always-scroll='true'
+                        alignment='Right'
+                        animation-type='ForwardAndReverse' />
+        <scrolling-text text='always scroll short continuous example'
+                        font-size='3'
+                        always-scroll='true'
+                        animation-type='Continuous' />
+
+        <!-- longer text speed examples -->
+        <scrolling-text text='this is a much longer example text than the previous example texts that should scroll because it is pretty long. if it doesn&apos;t scroll, then that means that this text is not long enough to activate the scroll animation coroutine. but if this is done correctly, then this long text should always activate the scroll animation coroutine'
+                        font-size='3'
+                        movement-type='BySpeed'
+                        scroll-speed='10'
+                        pause-duration='2'
+                        animation-type='Basic' />
+        <scrolling-text text='this is the second much longer example text than the shorter example texts that should scroll because it is pretty long. if it doesn&apos;t scroll, then that means that this text is not long enough to activate the scroll animation coroutine. but if this is done correctly, then this long text should always activate the scroll animation coroutine. also, this text is especially long to test whether or not the duration and speed scroll modes will have any differences. texts in duration mode should show a difference, whereas texts in speed mode should not'
+                        font-size='3'
+                        movement-type='BySpeed'
+                        scroll-speed='10'
+                        pause-duration='4'
+                        animation-type='FadeInOut' />
+        <scrolling-text text='this is the third much longer example text than the shorter example texts that should scroll because it is pretty long. if it doesn&apos;t scroll, then that means that this text is not long enough to activate the scroll animation coroutine. but if this is done correctly, then this long text should always activate the scroll animation coroutine'
+                        font-size='3'
+                        movement-type='BySpeed'
+                        alignment='Right'
+                        scroll-speed='10'
+                        pause-duration='4'
+                        animation-type='ForwardAndReverse' />
+        <scrolling-text text='this is the fourth much longer example text than the shorter example texts that should scroll because it is pretty long. if it doesn&apos;t scroll, then that means that this text is not long enough to activate the scroll animation coroutine. but if this is done correctly, then this long text should always activate the scroll animation coroutine. also, this text is especially long to test whether or not the duration and speed scroll modes will have any differences. texts in duration mode should show a difference, whereas texts in speed mode should not'
+                        font-size='3'
+                        movement-type='BySpeed'
+                        alignment='Right'
+                        scroll-speed='10'
+                        pause-duration='4'
+                        animation-type='Continuous' />
+
+        <scrolling-text text='~changeable-text'
+                        font-size='3'
+                        movement-type='BySpeed'
+                        alignment='Right'
+                        always-scroll='~always-scroll'
+                        scroll-speed='~scroll-speed'
+                        pause-duration='~pause-duration'
+                        animation-type='~animation-type' />
+      </vertical>
+    </horizontal>
   </tab>
 </bg>


### PR DESCRIPTION
Scrolling text for banners and other fancy stuff

Acts the same as a regular text tag (although it's missing some of the properties that the regular text tag has) until the text given to it is longer than the RectTransform. Once the text is longer, the text is scaled down to fit until the textWidthRatioThreshold (ratio between text width vs container width) is reached. This was done so the animation doesn't activate for text that is just barely longer than the container.

[This example view controller](https://github.com/monkeymanboy/BeatSaberMarkupLanguage/files/4284354/TestView.bsml.txt) results in [this](https://streamable.com/lcmva)

Also, added that enum parser in Parse. Probably should've been its own commit but ¯\\_(ツ)_/¯