### PR TITLE
Fix exception when CheckboxSetting doesn't have an associated value

### DIFF
--- a/BeatSaberMarkupLanguage/Components/Settings/CheckboxSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/CheckboxSetting.cs
@@ -39,13 +39,14 @@ namespace BeatSaberMarkupLanguage.Components.Settings
 
         public override void ApplyValue()
         {  //Mainly I do this so that it doesnt trigger after initially grabbing the value.
-            if (checkbox.isOn != (bool)associatedValue?.GetValue())
+            if (associatedValue != null && checkbox.isOn != (bool)associatedValue.GetValue())
                 associatedValue.SetValue(checkbox.isOn);
         }
 
         public override void ReceiveValue()
         {
-            CheckboxValue = (bool)associatedValue?.GetValue();
+            if (associatedValue != null)
+                CheckboxValue = (bool)associatedValue.GetValue();
         }
     }
 }


### PR DESCRIPTION
Adds a null check before trying to get the associated value of a `CheckboxSetting` to prevent a `NullReferenceException` when casting to `bool` if there is no associated value, similarly to how it is done in every other setting class.