### PR TITLE
Add BSMLAutomaticViewController, an easier way to use BSML

### DIFF
--- a/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
@@ -14,7 +14,7 @@ namespace BeatSaberMarkupLanguage.Attributes
     public sealed class HotReloadAttribute : Attribute
     {
         public string GivenPath { get; }
-        public string[][] Aliases { get; set; }
+        public string[] Aliases { get; set; }
 
         private string _path = null;
         public string Path
@@ -23,15 +23,16 @@ namespace BeatSaberMarkupLanguage.Attributes
             {
                 if (_path == null)
                 {
-                    foreach (var alias in Aliases)
+                    for (int i = 0; i < Aliases.Length; i += 2)
                     {
-                        if (alias.Length < 2) continue;
-                        if (GivenPath.StartsWith(alias[0]))
+                        if (i + 1 >= Aliases.Length) break;
+                        if (GivenPath.StartsWith(Aliases[i]))
                         {
-                            _path = alias[1] + GivenPath.Substring(alias[0].Length);
+                            _path = Aliases[i + 1] + GivenPath.Substring(Aliases[i].Length);
                             break;
                         }
                     }
+                    if (_path == null) _path = GivenPath;
                 }
                 return _path;
             }

--- a/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
@@ -14,7 +14,11 @@ namespace BeatSaberMarkupLanguage.Attributes
     public sealed class HotReloadAttribute : Attribute
     {
         public string GivenPath { get; }
-        public string[] Aliases { get; set; }
+        /// <summary>
+        /// There should always be an even number of elements, where the first is the thing to map from, 
+        /// and the second of each pair is the target.
+        /// </summary>
+        public string[] PathMap { get; set; }
 
         private string _path = null;
         public string Path
@@ -23,12 +27,12 @@ namespace BeatSaberMarkupLanguage.Attributes
             {
                 if (_path == null)
                 {
-                    for (int i = 0; i < Aliases.Length; i += 2)
+                    for (int i = 0; i < PathMap.Length; i += 2)
                     {
-                        if (i + 1 >= Aliases.Length) break;
-                        if (GivenPath.StartsWith(Aliases[i]))
+                        if (i + 1 >= PathMap.Length) break;
+                        if (GivenPath.StartsWith(PathMap[i]))
                         {
-                            _path = Aliases[i + 1] + GivenPath.Substring(Aliases[i].Length);
+                            _path = PathMap[i + 1] + GivenPath.Substring(PathMap[i].Length);
                             break;
                         }
                     }

--- a/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
@@ -27,13 +27,16 @@ namespace BeatSaberMarkupLanguage.Attributes
             {
                 if (_path == null)
                 {
-                    for (int i = 0; i < PathMap.Length; i += 2)
+                    if (PathMap != null)
                     {
-                        if (i + 1 >= PathMap.Length) break;
-                        if (GivenPath.StartsWith(PathMap[i]))
+                        for (int i = 0; i < PathMap.Length; i += 2)
                         {
-                            _path = PathMap[i + 1] + GivenPath.Substring(PathMap[i].Length);
-                            break;
+                            if (i + 1 >= PathMap.Length) break;
+                            if (GivenPath.StartsWith(PathMap[i]))
+                            {
+                                _path = PathMap[i + 1] + GivenPath.Substring(PathMap[i].Length);
+                                break;
+                            }
                         }
                     }
                     if (_path == null) _path = GivenPath;

--- a/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using IPA.Utilities;
+
+namespace BeatSaberMarkupLanguage.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [Conditional("DEBUG"), Conditional("USE_HOT_RELOAD")]
+    public sealed class HotReloadAttribute : Attribute
+    {
+        public string GivenPath { get; }
+        public string[][] Aliases { get; set; }
+
+        private string _path = null;
+        public string Path
+        {
+            get
+            {
+                if (_path == null)
+                {
+                    foreach (var alias in Aliases)
+                    {
+                        if (alias.Length < 2) continue;
+                        if (GivenPath.StartsWith(alias[0]))
+                        {
+                            _path = alias[1] + GivenPath.Substring(alias[0].Length);
+                            break;
+                        }
+                    }
+                }
+                return _path;
+            }
+        }
+
+        public HotReloadAttribute([CallerFilePath] string basePath = null)
+            => GivenPath = basePath;
+    }
+}

--- a/BeatSaberMarkupLanguage/Attributes/ViewDefinitionAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/ViewDefinitionAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class ViewDefinitionAttribute : Attribute
+    {
+        public string Definition { get; }
+
+        /// <summary>
+        /// When applied to a BSMLAutomaticViewController, indicates that it uses the embedded resource
+        /// <paramref name="definition"/> instead of the default name.
+        /// </summary>
+        /// <param name="definition">the name of the embedded resource to use</param>
+        public ViewDefinitionAttribute(string definition)
+            => Definition = definition;
+    }
+}

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -125,11 +125,13 @@
     <Compile Include="Animations\GIF\GIFUnityDecoder.cs" />
     <Compile Include="Animations\AnimationInfo.cs" />
     <Compile Include="Animations\LockBitmap.cs" />
+    <Compile Include="Attributes\HotReloadAttribute.cs" />
     <Compile Include="Attributes\UIAction.cs" />
     <Compile Include="Attributes\UIComponent.cs" />
     <Compile Include="Attributes\UIObject.cs" />
     <Compile Include="Attributes\UIParams.cs" />
     <Compile Include="Attributes\UIValue.cs" />
+    <Compile Include="Attributes\ViewDefinitionAttribute.cs" />
     <Compile Include="BeatSaberUI.cs" />
     <Compile Include="Components\BSMLScrollView.cs" />
     <Compile Include="Components\BSMLTableView.cs" />
@@ -276,10 +278,12 @@
     <Compile Include="TypeHandlers\TextSegmentedControlHandler.cs" />
     <Compile Include="TypeHandlers\TypeHandler.cs" />
     <Compile Include="Utilities.cs" />
+    <Compile Include="ViewControllers\BSMLAutomaticViewController.cs" />
     <Compile Include="ViewControllers\BSMLResourceViewController.cs" />
     <Compile Include="ViewControllers\BSMLViewController.cs" />
     <Compile Include="ViewControllers\HotReloadableViewController.cs" />
     <Compile Include="ViewControllers\TestViewController.cs" />
+    <Compile Include="ViewControllers\WatcherGroup.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\test.bsml" />

--- a/BeatSaberMarkupLanguage/ViewControllers/BSMLAutomaticViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/BSMLAutomaticViewController.cs
@@ -1,0 +1,44 @@
+﻿using BeatSaberMarkupLanguage.Attributes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.ViewControllers
+{
+    public abstract class BSMLAutomaticViewController : BSMLViewController
+    {
+        private static string GetDefaultResourceName(Type type)
+        {
+            var ns = type.Namespace;
+            var name = type.Name;
+            return (ns.Length > 0 ? ns + "." : "") + name + ".bsml";
+        }
+
+        private string _resourceName;
+        public override string Content 
+        {
+            get
+            {
+                if (_resourceName == null)
+                {
+                    var viewDef = GetType().GetCustomAttribute<ViewDefinitionAttribute>();
+                    if (viewDef != null) _resourceName = viewDef.Definition;
+                    else _resourceName = GetDefaultResourceName(GetType());
+                }
+                return Utilities.GetResourceContent(GetType().Assembly, _resourceName);
+            } 
+        }
+
+        private readonly string hotReloadFrom;
+        public BSMLAutomaticViewController() : base()
+        {
+            var hotReloadAttr = GetType().GetCustomAttribute<HotReloadAttribute>();
+            if (hotReloadAttr == null) hotReloadFrom = null;
+            else hotReloadFrom = Path.ChangeExtension(hotReloadAttr.Path, ".bsml");
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/ViewControllers/BSMLAutomaticViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/BSMLAutomaticViewController.cs
@@ -73,7 +73,7 @@ namespace BeatSaberMarkupLanguage.ViewControllers
 
         string WatcherGroup.IHotReloadableController.Name => name;
 
-        public BSMLAutomaticViewController() : base()
+        protected BSMLAutomaticViewController() : base()
         {
             var hotReloadAttr = GetType().GetCustomAttribute<HotReloadAttribute>();
             if (hotReloadAttr == null) ContentFilePath = null;
@@ -163,11 +163,6 @@ namespace BeatSaberMarkupLanguage.ViewControllers
                     Logger.log?.Error(ex);
                 }
             }
-        }
-
-        int WatcherGroup.IHotReloadableController.GetInstanceID()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/BeatSaberMarkupLanguage/ViewControllers/BSMLAutomaticViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/BSMLAutomaticViewController.cs
@@ -1,4 +1,8 @@
-﻿using BeatSaberMarkupLanguage.Attributes;
+﻿#if DEBUG
+#define HRVC_DEBUG
+#endif
+using BeatSaberMarkupLanguage.Attributes;
+using HMUI;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,10 +10,11 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace BeatSaberMarkupLanguage.ViewControllers
 {
-    public abstract class BSMLAutomaticViewController : BSMLViewController
+    public abstract class BSMLAutomaticViewController : BSMLViewController, WatcherGroup.IHotReloadableController
     {
         private static string GetDefaultResourceName(Type type)
         {
@@ -17,8 +22,15 @@ namespace BeatSaberMarkupLanguage.ViewControllers
             var name = type.Name;
             return (ns.Length > 0 ? ns + "." : "") + name + ".bsml";
         }
+        public virtual string FallbackContent => @"<vertical child-control-height='false' child-control-width='true' child-align='UpperCenter' pref-width='110' pad-left='3' pad-right='3'>
+                                                      <horizontal bg='panel-top' pad-left='10' pad-right='10' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
+                                                        <text text='Invalid BSML' font-size='10'/>
+                                                      </horizontal>
+                                                      <text text='{0}' font-size='5'/>
+                                                    </vertical>";
 
         private string _resourceName;
+        private string _content;
         public override string Content 
         {
             get
@@ -29,16 +41,133 @@ namespace BeatSaberMarkupLanguage.ViewControllers
                     if (viewDef != null) _resourceName = viewDef.Definition;
                     else _resourceName = GetDefaultResourceName(GetType());
                 }
-                return Utilities.GetResourceContent(GetType().Assembly, _resourceName);
+                if (string.IsNullOrEmpty(_content))
+                {
+                    if (!string.IsNullOrEmpty(ContentFilePath) && File.Exists(ContentFilePath))
+                    {
+                        try
+                        {
+                            _content = File.ReadAllText(ContentFilePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.log?.Warn($"Unable to read file {ContentFilePath} for {name}: {ex.Message}");
+                            Logger.log?.Debug(ex);
+                        }
+                    }
+                    if (string.IsNullOrEmpty(_content) && !string.IsNullOrEmpty(_resourceName))
+                    {
+#if HRVC_DEBUG
+                        Logger.log.Warn($"No content from file {ContentFilePath}, using resource {_resourceName}");
+#endif
+                        _content = Utilities.GetResourceContent(GetType().Assembly, _resourceName);
+                    }
+                }
+                return _content;
             } 
         }
 
-        private readonly string hotReloadFrom;
+        public bool ContentChanged { get; protected set; }
+
+        public string ContentFilePath { get; }
+
+        string WatcherGroup.IHotReloadableController.Name => name;
+
         public BSMLAutomaticViewController() : base()
         {
             var hotReloadAttr = GetType().GetCustomAttribute<HotReloadAttribute>();
-            if (hotReloadAttr == null) hotReloadFrom = null;
-            else hotReloadFrom = Path.ChangeExtension(hotReloadAttr.Path, ".bsml");
+            if (hotReloadAttr == null) ContentFilePath = null;
+            else ContentFilePath = Path.ChangeExtension(hotReloadAttr.Path, ".bsml");
+        }
+
+        protected override void DidActivate(bool firstActivation, ActivationType type)
+        {
+            if (string.IsNullOrEmpty(ContentFilePath)) return;
+
+            if (ContentChanged && !firstActivation)
+            {
+                ContentChanged = false;
+                ParseWithFallback();
+            }
+            else if (firstActivation)
+                ParseWithFallback();
+            bool registered = WatcherGroup.RegisterViewController(this);
+#if HRVC_DEBUG
+            if (registered)
+                Logger.log.Info($"Registered {this.name}");
+            else
+                Logger.log.Error($"Failed to register {this.name}");
+#endif
+
+            didActivate?.Invoke(firstActivation, type);
+        }
+
+
+        protected override void DidDeactivate(DeactivationType deactivationType)
+        {
+            if (string.IsNullOrEmpty(ContentFilePath)) return;
+
+            _content = null;
+#if HRVC_DEBUG
+            Logger.log.Warn($"DidDeactive: {GetInstanceID()}:{name}");
+#endif
+            if (!WatcherGroup.UnregisterViewController(this))
+            {
+#if HRVC_DEBUG
+                Logger.log.Warn($"Failed to Unregister {GetInstanceID()}:{name}");
+#endif
+            }
+            base.DidDeactivate(deactivationType);
+        }
+
+        private void ParseWithFallback()
+        {
+            try
+            {
+                BSMLParser.instance.Parse(Content, gameObject, this);
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"Error parsing BSML: {ex.Message}");
+                Logger.log.Debug(ex);
+                BSMLParser.instance.Parse(string.Format(FallbackContent, Utilities.EscapeXml(ex.Message)), gameObject, this);
+            }
+        }
+
+        void WatcherGroup.IHotReloadableController.MarkDirty()
+        {
+            ContentChanged = true;
+            _content = null;
+        }
+
+        void WatcherGroup.IHotReloadableController.Refresh(bool forceReload)
+        {
+            if (!isActiveAndEnabled)
+            {
+#if HRVC_DEBUG
+                Logger.log.Warn($"Trying to refresh {GetInstanceID()}:{name} when it isn't ActiveAndEnabled.");
+#endif
+                return;
+            }
+            if (ContentChanged || forceReload)
+            {
+                try
+                {
+                    __Deactivate(ViewController.DeactivationType.NotRemovedFromHierarchy, false);
+                    for (int i = 0; i < transform.childCount; i++)
+                        GameObject.Destroy(transform.GetChild(i).gameObject);
+                    __Activate(ViewController.ActivationType.NotAddedToHierarchy);
+                }
+                catch (Exception ex)
+                {
+                    Logger.log?.Error(ex);
+                }
+            }
+        }
+
+        int WatcherGroup.IHotReloadableController.GetInstanceID()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/BeatSaberMarkupLanguage/ViewControllers/HotReloadableViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/HotReloadableViewController.cs
@@ -26,7 +26,7 @@ namespace BeatSaberMarkupLanguage.ViewControllers
             (viewController as WatcherGroup.IHotReloadableController).Refresh(forceReload);
         }
 
-        void WatcherGroup.IHotReloadableController.Refresh(bool forceReload = false)
+        void WatcherGroup.IHotReloadableController.Refresh(bool forceReload)
         {
             if (!isActiveAndEnabled)
             {
@@ -58,7 +58,7 @@ namespace BeatSaberMarkupLanguage.ViewControllers
                                                       <horizontal bg='panel-top' pad-left='10' pad-right='10' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
                                                         <text text='Invalid BSML' font-size='10'/>
                                                       </horizontal>
-                                                      <text text ='{0}' font-size='5'/>
+                                                      <text text='{0}' font-size='5'/>
                                                     </vertical>";
 
         private string _content;

--- a/BeatSaberMarkupLanguage/ViewControllers/HotReloadableViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/HotReloadableViewController.cs
@@ -11,197 +11,8 @@ using HMUI;
 
 namespace BeatSaberMarkupLanguage.ViewControllers
 {
-    public abstract class HotReloadableViewController : BSMLViewController
+    public abstract class HotReloadableViewController : BSMLViewController, WatcherGroup.IHotReloadableController
     {
-        #region FileSystemWatcher
-        internal class WatcherGroup
-        {
-            internal FileSystemWatcher Watcher { get; private set; }
-
-            internal string ContentDirectory { get; private set; }
-            
-            internal bool IsReloading { get; private set; }
-
-            private readonly WaitForSeconds HotReloadDelay = new WaitForSeconds(.5f);
-
-            private readonly Dictionary<int, WeakReference<HotReloadableViewController>> BoundControllers = new Dictionary<int, WeakReference<HotReloadableViewController>>();
-
-            internal WatcherGroup(string directory)
-            {
-                ContentDirectory = directory;
-                CreateWatcher();
-            }
-
-            private void CreateWatcher()
-            {
-                if (Watcher != null) return;
-                if (!Directory.Exists(ContentDirectory)) return;
-#if HRVC_DEBUG
-                Logger.log.Critical($"Creating FileSystemWatcher for {ContentDirectory}");
-#endif
-                Watcher = new FileSystemWatcher(ContentDirectory, "*.bsml")
-                {
-                    NotifyFilter = NotifyFilters.LastWrite
-                };
-                Watcher.Changed += OnFileWasChanged;
-            }
-
-            private void DestroyWatcher()
-            {
-#if HRVC_DEBUG
-                Logger.log.Critical($"Destroying FileSystemWatcher for {ContentDirectory}");
-#endif
-                Watcher.Dispose();
-                Watcher = null;
-            }
-
-            private void OnFileWasChanged(object sender, FileSystemEventArgs e)
-            {
-                foreach (KeyValuePair<int, WeakReference<HotReloadableViewController>> pair in BoundControllers.ToArray())
-                {
-                    if (!pair.Value.TryGetTarget(out HotReloadableViewController controller))
-                    {
-#if HRVC_DEBUG
-                        Logger.log.Critical($"Watcher_Changed: {pair.Key} has been Garbage Collected, unbinding.");
-#endif
-                        UnbindController(pair.Key);
-                        continue;
-                    }
-                    if (e.FullPath == Path.GetFullPath(controller.ContentFilePath))
-                    {
-                        controller.MarkDirty();
-                        HMMainThreadDispatcher.instance.Enqueue(HotReloadCoroutine());
-                    }
-                }
-                if (BoundControllers.Count == 0)
-                {
-#if HRVC_DEBUG
-                    Logger.log.Critical($"BoundControllers is empty in Watcher_Changed.");
-#endif
-                    DestroyWatcher();
-                }
-            }
-
-            private IEnumerator<WaitForSeconds> HotReloadCoroutine()
-            {
-                if (IsReloading) yield break;
-                IsReloading = true;
-                yield return HotReloadDelay;
-                KeyValuePair<int, WeakReference<HotReloadableViewController>>[] array = BoundControllers.ToArray();
-                for (int i = 0; i < array.Length; i++)
-                {
-                    KeyValuePair<int, WeakReference<HotReloadableViewController>> pair = array[i];
-                    if (!pair.Value.TryGetTarget(out HotReloadableViewController controller))
-                    {
-#if HRVC_DEBUG
-                        Logger.log.Critical($"{pair.Key} has been Garbage Collected, unbinding.");
-#endif
-                        UnbindController(pair.Key);
-                        continue;
-                    }
-                    if (controller.ContentChanged)
-                    {
-#if HRVC_DEBUG
-                        Logger.log.Critical($"{pair.Key} seems to exist and has changed content.");
-#endif
-                        RefreshViewController(controller);
-                    }
-                }
-                IsReloading = false;
-            }
-            
-            internal bool BindController(HotReloadableViewController controller)
-            {
-                if (BoundControllers.ContainsKey(controller.GetInstanceID()))
-                {
-#if HRVC_DEBUG
-                    Logger.log.Critical($"Failed to register controller, already exists. {controller.GetInstanceID()}:{controller.name}");
-#endif
-                    return false;
-                }
-                BoundControllers.Add(controller.GetInstanceID(), new WeakReference<HotReloadableViewController>(controller));
-                CreateWatcher();
-                Watcher.EnableRaisingEvents = true;
-#if HRVC_DEBUG
-                Logger.log.Info($"Registering controller {controller.GetInstanceID()}:{controller.name}");
-#endif
-                return true;
-            }
-
-            internal bool UnbindController(int instanceId)
-            {
-#if HRVC_DEBUG
-                if (BoundControllers.TryGetValue(instanceId, out WeakReference<HotReloadableViewController> controllerRef))
-                    if (!controllerRef.TryGetTarget(out HotReloadableViewController controller))
-                        Logger.log.Warn($"Unbinding garbage collected controller {instanceId}");
-                    else
-                        Logger.log.Warn($"Unbinding existing controller {instanceId}:{controller.name}");
-                else
-                    Logger.log.Warn($"Trying to unbind controller that isn't in the dictionary");
-#endif
-                bool remove = BoundControllers.Remove(instanceId);
-                if (BoundControllers.Count == 0)
-                    DestroyWatcher();
-                return remove;
-            }
-
-            internal bool UnbindController(HotReloadableViewController controller)
-            {
-                if (controller == null)
-                {
-#if HRVC_DEBUG
-                    Logger.log.Critical($"Unable to unbind controller, it is null.");
-#endif
-                    return false;
-                }
-                return UnbindController(controller.GetInstanceID());
-            }
-        }
-
-        private static readonly Dictionary<string, WatcherGroup> WatcherDictionary = new Dictionary<string, WatcherGroup>();
-        public static bool RegisterViewController(HotReloadableViewController controller)
-        {
-            string contentFile = controller.ContentFilePath;
-            if (string.IsNullOrEmpty(contentFile)) return false;
-            string contentDirectory = Path.GetDirectoryName(contentFile);
-            if (!Directory.Exists(contentDirectory)) return false;
-            WatcherGroup watcherGroup;
-            if (!WatcherDictionary.TryGetValue(contentDirectory, out watcherGroup))
-            {
-                watcherGroup = new WatcherGroup(contentDirectory);
-                WatcherDictionary.Add(contentDirectory, watcherGroup);
-            }
-            watcherGroup.BindController(controller);
-
-            return true;
-        }
-
-        public static bool UnregisterViewController(HotReloadableViewController controller)
-        {
-            string contentFile = controller.ContentFilePath;
-            if (string.IsNullOrEmpty(contentFile))
-            {
-#if HRVC_DEBUG
-                Logger.log.Critical($"Skipping registration for {controller.GetInstanceID()}:{controller.name}, it has not content file defined.");
-#endif
-                return false;
-            }
-            bool successful = false;
-            string contentDirectory = Path.GetDirectoryName(contentFile);
-            if (WatcherDictionary.TryGetValue(contentDirectory, out WatcherGroup watcherGroup))
-                successful = watcherGroup.UnbindController(controller);
-#if HRVC_DEBUG
-            else
-                Logger.log.Warn($"Unable to get WatcherGroup for {contentDirectory}");
-            if (successful)
-                Logger.log.Info($"Successfully unregistered {controller.GetInstanceID()}:{controller.name}");
-            else
-                Logger.log.Warn($"Failed to Unregister {controller.GetInstanceID()}:{controller.name}");
-#endif
-            return successful;
-        }
-
-        #endregion
 
         public static void RefreshViewController(HotReloadableViewController viewController, bool forceReload = false)
         {
@@ -212,21 +23,26 @@ namespace BeatSaberMarkupLanguage.ViewControllers
 #endif
                 return;
             }
-            if (!viewController.isActiveAndEnabled)
+            (viewController as WatcherGroup.IHotReloadableController).Refresh(forceReload);
+        }
+
+        void WatcherGroup.IHotReloadableController.Refresh(bool forceReload = false)
+        {
+            if (!isActiveAndEnabled)
             {
 #if HRVC_DEBUG
-                Logger.log.Warn($"Trying to refresh {viewController.GetInstanceID()}:{viewController.name} when it isn't ActiveAndEnabled.");
+                Logger.log.Warn($"Trying to refresh {GetInstanceID()}:{name} when it isn't ActiveAndEnabled.");
 #endif
                 return;
             }
-            if (viewController.ContentChanged || forceReload)
+            if (ContentChanged || forceReload)
             {
                 try
                 {
-                    viewController.__Deactivate(ViewController.DeactivationType.NotRemovedFromHierarchy, false);
-                    for (int i = 0; i < viewController.transform.childCount; i++)
-                        GameObject.Destroy(viewController.transform.GetChild(i).gameObject);
-                    viewController.__Activate(ViewController.ActivationType.NotAddedToHierarchy);
+                    __Deactivate(ViewController.DeactivationType.NotRemovedFromHierarchy, false);
+                    for (int i = 0; i < transform.childCount; i++)
+                        GameObject.Destroy(transform.GetChild(i).gameObject);
+                    __Activate(ViewController.ActivationType.NotAddedToHierarchy);
                 }
                 catch (Exception ex)
                 {
@@ -278,6 +94,8 @@ namespace BeatSaberMarkupLanguage.ViewControllers
 
         public bool ContentChanged { get; protected set; }
 
+        string WatcherGroup.IHotReloadableController.Name => name;
+
         protected override void DidActivate(bool firstActivation, ActivationType type)
         {
             if (ContentChanged && !firstActivation)
@@ -287,7 +105,7 @@ namespace BeatSaberMarkupLanguage.ViewControllers
             }
             else if (firstActivation)
                 ParseWithFallback();
-            bool registered = RegisterViewController(this);
+            bool registered = WatcherGroup.RegisterViewController(this);
 #if HRVC_DEBUG
             if (registered)
                 Logger.log.Info($"Registered {this.name}");
@@ -305,7 +123,7 @@ namespace BeatSaberMarkupLanguage.ViewControllers
 #if HRVC_DEBUG
             Logger.log.Warn($"DidDeactive: {GetInstanceID()}:{name}");
 #endif
-            if (!UnregisterViewController(this))
+            if (!WatcherGroup.UnregisterViewController(this))
             {
 #if HRVC_DEBUG
                 Logger.log.Warn($"Failed to Unregister {GetInstanceID()}:{name}");

--- a/BeatSaberMarkupLanguage/ViewControllers/WatcherGroup.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/WatcherGroup.cs
@@ -1,0 +1,213 @@
+﻿#if DEBUG
+#define HRVC_DEBUG
+#endif
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.ViewControllers
+{
+    internal class WatcherGroup
+    {
+        internal interface IHotReloadableController
+        {
+            bool ContentChanged { get; }
+            string ContentFilePath { get; }
+            string Name { get; }
+            void MarkDirty();
+            void Refresh(bool forceReload = false);
+            int GetInstanceID();
+        }
+
+        internal FileSystemWatcher Watcher { get; private set; }
+
+        internal string ContentDirectory { get; private set; }
+            
+        internal bool IsReloading { get; private set; }
+
+        private readonly WaitForSeconds HotReloadDelay = new WaitForSeconds(.5f);
+
+        private readonly Dictionary<int, WeakReference<IHotReloadableController>> BoundControllers = new Dictionary<int, WeakReference<IHotReloadableController>>();
+
+        internal WatcherGroup(string directory)
+        {
+            ContentDirectory = directory;
+            CreateWatcher();
+        }
+
+        private void CreateWatcher()
+        {
+            if (Watcher != null) return;
+            if (!Directory.Exists(ContentDirectory)) return;
+#if HRVC_DEBUG
+            Logger.log.Critical($"Creating FileSystemWatcher for {ContentDirectory}");
+#endif
+            Watcher = new FileSystemWatcher(ContentDirectory, "*.bsml")
+            {
+                NotifyFilter = NotifyFilters.LastWrite
+            };
+            Watcher.Changed += OnFileWasChanged;
+        }
+
+        private void DestroyWatcher()
+        {
+#if HRVC_DEBUG
+            Logger.log.Critical($"Destroying FileSystemWatcher for {ContentDirectory}");
+#endif
+            Watcher.Dispose();
+            Watcher = null;
+        }
+
+        private void OnFileWasChanged(object sender, FileSystemEventArgs e)
+        {
+            foreach (KeyValuePair<int, WeakReference<IHotReloadableController>> pair in BoundControllers.ToArray())
+            {
+                if (!pair.Value.TryGetTarget(out IHotReloadableController controller))
+                {
+#if HRVC_DEBUG
+                    Logger.log.Critical($"Watcher_Changed: {pair.Key} has been Garbage Collected, unbinding.");
+#endif
+                    UnbindController(pair.Key);
+                    continue;
+                }
+                if (e.FullPath == Path.GetFullPath(controller.ContentFilePath))
+                {
+                    controller.MarkDirty();
+                    HMMainThreadDispatcher.instance.Enqueue(HotReloadCoroutine());
+                }
+            }
+            if (BoundControllers.Count == 0)
+            {
+#if HRVC_DEBUG
+                Logger.log.Critical($"BoundControllers is empty in Watcher_Changed.");
+#endif
+                DestroyWatcher();
+            }
+        }
+
+        private IEnumerator<WaitForSeconds> HotReloadCoroutine()
+        {
+            if (IsReloading) yield break;
+            IsReloading = true;
+            yield return HotReloadDelay;
+            KeyValuePair<int, WeakReference<IHotReloadableController>>[] array = BoundControllers.ToArray();
+            for (int i = 0; i < array.Length; i++)
+            {
+                KeyValuePair<int, WeakReference<IHotReloadableController>> pair = array[i];
+                if (!pair.Value.TryGetTarget(out IHotReloadableController controller))
+                {
+#if HRVC_DEBUG
+                    Logger.log.Critical($"{pair.Key} has been Garbage Collected, unbinding.");
+#endif
+                    UnbindController(pair.Key);
+                    continue;
+                }
+                if (controller.ContentChanged)
+                {
+#if HRVC_DEBUG
+                    Logger.log.Critical($"{pair.Key} seems to exist and has changed content.");
+#endif
+                    if (controller != null)
+                        controller.Refresh();
+                    //RefreshViewController(controller);
+                }
+            }
+            IsReloading = false;
+        }
+            
+        internal bool BindController(IHotReloadableController controller)
+        {
+            if (BoundControllers.ContainsKey(controller.GetInstanceID()))
+            {
+#if HRVC_DEBUG
+                Logger.log.Critical($"Failed to register controller, already exists. {controller.GetInstanceID()}:{controller.Name}");
+#endif
+                return false;
+            }
+            BoundControllers.Add(controller.GetInstanceID(), new WeakReference<IHotReloadableController>(controller));
+            CreateWatcher();
+            Watcher.EnableRaisingEvents = true;
+#if HRVC_DEBUG
+            Logger.log.Info($"Registering controller {controller.GetInstanceID()}:{controller.Name}");
+#endif
+            return true;
+        }
+
+        internal bool UnbindController(int instanceId)
+        {
+#if HRVC_DEBUG
+            if (BoundControllers.TryGetValue(instanceId, out WeakReference<IHotReloadableController> controllerRef))
+                if (!controllerRef.TryGetTarget(out IHotReloadableController controller))
+                    Logger.log.Warn($"Unbinding garbage collected controller {instanceId}");
+                else
+                    Logger.log.Warn($"Unbinding existing controller {instanceId}:{controller.Name}");
+            else
+                Logger.log.Warn($"Trying to unbind controller that isn't in the dictionary");
+#endif
+            bool remove = BoundControllers.Remove(instanceId);
+            if (BoundControllers.Count == 0)
+                DestroyWatcher();
+            return remove;
+        }
+
+        internal bool UnbindController(IHotReloadableController controller)
+        {
+            if (controller == null)
+            {
+#if HRVC_DEBUG
+                Logger.log.Critical($"Unable to unbind controller, it is null.");
+#endif
+                return false;
+            }
+            return UnbindController(controller.GetInstanceID());
+        }
+
+
+        private static readonly Dictionary<string, WatcherGroup> WatcherDictionary = new Dictionary<string, WatcherGroup>();
+        public static bool RegisterViewController(IHotReloadableController controller)
+        {
+            string contentFile = controller.ContentFilePath;
+            if (string.IsNullOrEmpty(contentFile)) return false;
+            string contentDirectory = Path.GetDirectoryName(contentFile);
+            if (!Directory.Exists(contentDirectory)) return false;
+            WatcherGroup watcherGroup;
+            if (!WatcherDictionary.TryGetValue(contentDirectory, out watcherGroup))
+            {
+                watcherGroup = new WatcherGroup(contentDirectory);
+                WatcherDictionary.Add(contentDirectory, watcherGroup);
+            }
+            watcherGroup.BindController(controller);
+
+            return true;
+        }
+
+        public static bool UnregisterViewController(IHotReloadableController controller)
+        {
+            string contentFile = controller.ContentFilePath;
+            if (string.IsNullOrEmpty(contentFile))
+            {
+#if HRVC_DEBUG
+                Logger.log.Critical($"Skipping registration for {controller.GetInstanceID()}:{controller.Name}, it has not content file defined.");
+#endif
+                return false;
+            }
+            bool successful = false;
+            string contentDirectory = Path.GetDirectoryName(contentFile);
+            if (WatcherDictionary.TryGetValue(contentDirectory, out WatcherGroup watcherGroup))
+                successful = watcherGroup.UnbindController(controller);
+#if HRVC_DEBUG
+            else
+                Logger.log.Warn($"Unable to get WatcherGroup for {contentDirectory}");
+            if (successful)
+                Logger.log.Info($"Successfully unregistered {controller.GetInstanceID()}:{controller.Name}");
+            else
+                Logger.log.Warn($"Failed to Unregister {controller.GetInstanceID()}:{controller.Name}");
+#endif
+            return successful;
+        }
+
+    }
+}
+


### PR DESCRIPTION
This PR adds a `BSMLAutomaticViewController` that provides the features of both `BSMLResourceViewController` and `HotReloadableViewController`, but with the control knobs being the new attributes `ViewDefinitionAttribute` and `HotReloadAttribute`.

---

Basic usage of `BSMLAutomaticViewController` is as follows:
```cs
internal class TestViewController : BSMLAutomaticViewController
{
}
```
This will look for a resource in the same location as the class, with the `.bsml` extension. For example, if the above `TestViewController` were in the namespace `BSMLTest.UI`, then the resource it would look for would be `BSMLTest.UI.TestViewController.bsml`.

That resource can also be specified manually using `ViewDefinitionAttribute`, as follows:
```cs
[ViewDefinition("embedded_resource_name")]
internal class TestViewController : BSMLAutomaticViewController
{
}
```
In the above example, the view controller will use the embedded resource `embedded_resource_name` as the source for the loading.

---

To use the hot reloading feature, simply add the `[HotReload]` attribute to the type, as shown below.
```cs
[HotReload]
internal class TestViewController : BSMLAutomaticViewController
{
}
```
This will, in debug builds, watch the file neighboring the source file that defines the class, with its extension replaced with `.bsml`. So in the above example, if it is defined in `TestViewController.cs`, then BSML will reload from `TestViewController.bsml` right next to it. It should be trivial to extend this to allow more control, though I have not done so.

If your build is configured to use a path map for symbol information, then you may also provide a reverse path map as the `PathMap` property of the `HotReload` attribute. It will be used to correct the search path appropriately, like so:
```cs
[HotReload(PathMap = new[] { "C:", CompileConstants.SolutionDirectory })]
internal class TestViewController : BSMLAutomaticViewController
{
}
```
The above example has a path map mapping the solution directory to `C:`, so the reload attribute specifies the reverse, where `CompileConstants.SolutionDirectory` is the full path to the solution being compiled. This can be injected through compile steps as necessary, including using T4, which is built in to Visual Studio.

The `HotReload` attribute is ignored if neither the `DEBUG` nor the `USE_HOT_RELOAD` preprocessor symbols are enabled, because in a typical workflow, it only makes sense if a debug context.