### PR TITLE
Add a general, extremely customizable scroll view tag

### DIFF
--- a/BeatSaberMarkupLanguage/BSMLParser.cs
+++ b/BeatSaberMarkupLanguage/BSMLParser.cs
@@ -130,25 +130,33 @@ namespace BeatSaberMarkupLanguage
                 }
             }
 
+            IEnumerable<ComponentTypeWithData> componentInfo = Enumerable.Empty<ComponentTypeWithData>();
             foreach (XmlNode node in parentNode.ChildNodes)
-                HandleNode(node, parent, parserParams);
+            {
+                HandleNode(node, parent, parserParams, out IEnumerable<ComponentTypeWithData> components);
+                componentInfo = componentInfo.Concat(components);
+            }
 
             foreach (KeyValuePair<string, BSMLAction> action in parserParams.actions.Where(x => x.Key.StartsWith(SUBSCRIVE_EVENT_ACTION_PREFIX)))
                 parserParams.AddEvent(action.Key.Substring(1), delegate { action.Value.Invoke(); });
+
+            foreach (ComponentTypeWithData component in componentInfo)
+                component.typeHandler.HandleTypeAfterParse(component, parserParams);
 
             parserParams.EmitEvent("post-parse");
 
             return parserParams;
         }
 
-        public void HandleNode(XmlNode node, GameObject parent, BSMLParserParams parserParams)
+        public void HandleNode(XmlNode node, GameObject parent, BSMLParserParams parserParams, out IEnumerable<ComponentTypeWithData> componentInfo)
         {
+            componentInfo = Enumerable.Empty<ComponentTypeWithData>();
             if (node.Name.StartsWith(MACRO_PREFIX))
                 HandleMacroNode(node, parent, parserParams);
             else
-                HandleTagNode(node, parent, parserParams);
+                HandleTagNode(node, parent, parserParams, out componentInfo);
         }
-        private void HandleTagNode(XmlNode node, GameObject parent, BSMLParserParams parserParams)
+        private void HandleTagNode(XmlNode node, GameObject parent, BSMLParserParams parserParams, out IEnumerable<ComponentTypeWithData> componentInfo)
         {
 
             if (!tags.TryGetValue(node.Name, out BSMLTag currentTag))
@@ -194,14 +202,17 @@ namespace BeatSaberMarkupLanguage
             if (node.Attributes["tags"] != null)
                 parserParams.AddObjectTags(currentNode, node.Attributes["tags"].Value.Split(','));
 
+            IEnumerable<ComponentTypeWithData> childrenComponents = Enumerable.Empty<ComponentTypeWithData>();
             if (currentTag.AddChildren)
                 foreach (XmlNode childNode in node.ChildNodes)
-                    HandleNode(childNode, currentNode, parserParams);
+                    HandleNode(childNode, currentNode, parserParams, out childrenComponents);
 
             foreach (ComponentTypeWithData componentType in componentTypes)
             {
                 componentType.typeHandler.HandleTypeAfterChildren(componentType, parserParams);
             }
+
+            componentInfo = componentTypes.Concat(childrenComponents);
         }
 
         private Component GetExternalComponent(GameObject gameObject, Type type)

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Attributes\UIValue.cs" />
     <Compile Include="Attributes\ViewDefinitionAttribute.cs" />
     <Compile Include="BeatSaberUI.cs" />
+    <Compile Include="Components\BSMLScrollIndicator.cs" />
     <Compile Include="Components\BSMLScrollView.cs" />
     <Compile Include="Components\BSMLScrollViewElement.cs" />
     <Compile Include="Components\BSMLScrollViewContent.cs" />
@@ -223,6 +224,7 @@
     <Compile Include="Tags\ModalTag.cs" />
     <Compile Include="Tags\PageButtonTag.cs" />
     <Compile Include="Tags\ScrollableSettingsContainerTag.cs" />
+    <Compile Include="Tags\ScrollIndicatorTag.cs" />
     <Compile Include="Tags\ScrollViewTag.cs" />
     <Compile Include="Tags\SettingsContainerTag.cs" />
     <Compile Include="Tags\Settings\BoolSettingTag.cs" />
@@ -267,6 +269,7 @@
     <Compile Include="TypeHandlers\ModalViewHandler.cs" />
     <Compile Include="TypeHandlers\PageButtonHandler.cs" />
     <Compile Include="TypeHandlers\RectTransformHandler.cs" />
+    <Compile Include="TypeHandlers\ScrollIndicatorHandler.cs" />
     <Compile Include="TypeHandlers\ScrollViewHandler.cs" />
     <Compile Include="TypeHandlers\Settings\DropDownListSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\GenericSettingHandler.cs" />

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -134,6 +134,8 @@
     <Compile Include="Attributes\ViewDefinitionAttribute.cs" />
     <Compile Include="BeatSaberUI.cs" />
     <Compile Include="Components\BSMLScrollView.cs" />
+    <Compile Include="Components\BSMLScrollViewElement.cs" />
+    <Compile Include="Components\BSMLScrollViewContent.cs" />
     <Compile Include="Components\BSMLTableView.cs" />
     <Compile Include="Components\ButtonArtworkImage.cs" />
     <Compile Include="Components\ButtonIconImage.cs" />
@@ -221,6 +223,7 @@
     <Compile Include="Tags\ModalTag.cs" />
     <Compile Include="Tags\PageButtonTag.cs" />
     <Compile Include="Tags\ScrollableSettingsContainerTag.cs" />
+    <Compile Include="Tags\ScrollViewTag.cs" />
     <Compile Include="Tags\SettingsContainerTag.cs" />
     <Compile Include="Tags\Settings\BoolSettingTag.cs" />
     <Compile Include="Tags\Settings\CheckboxSettingTag.cs" />
@@ -264,6 +267,7 @@
     <Compile Include="TypeHandlers\ModalViewHandler.cs" />
     <Compile Include="TypeHandlers\PageButtonHandler.cs" />
     <Compile Include="TypeHandlers\RectTransformHandler.cs" />
+    <Compile Include="TypeHandlers\ScrollViewHandler.cs" />
     <Compile Include="TypeHandlers\Settings\DropDownListSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\GenericSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\IncrementSettingHandler.cs" />

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollIndicator.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollIndicator.cs
@@ -1,0 +1,19 @@
+﻿using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class BSMLScrollIndicator : VerticalScrollIndicator
+    {
+        public RectTransform Handle
+        {
+            get => _handle;
+            set => _handle = value;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollViewContent.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollViewContent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class BSMLScrollViewContent : MonoBehaviour
+    {
+        public BSMLScrollViewElement ScrollView { get; set; }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
@@ -1,0 +1,81 @@
+﻿using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class BSMLScrollViewElement : ScrollView
+    {
+        public Button PageUpButton
+        {
+            get => _pageUpButton;
+            set => _pageUpButton = value;
+        }
+        public Button PageDownButton
+        {
+            get => _pageDownButton;
+            set => _pageDownButton = value;
+        }
+
+        public RectTransform Viewport
+        {
+            get => _viewport;
+            set => _viewport = value;
+        }
+
+        public RectTransform ContentRect
+        {
+            get => _contentRectTransform;
+            set => _contentRectTransform = value;
+        }
+
+        public VerticalScrollIndicator ScrollIndicator
+        {
+            get => _verticalScrollIndicator;
+            set => _verticalScrollIndicator = value;
+        }
+
+        public override void Awake()
+        {
+            _buttonBinder = new ButtonBinder();
+
+            Setup();
+            RefreshButtonsInteractibility();
+            enabled = false;
+        }
+
+        public override void Setup()
+        {
+            _buttonBinder.ClearBindings();
+            if (PageUpButton != null)
+                _buttonBinder.AddBinding(PageUpButton, PageUpButtonPressed);
+            if (PageDownButton != null)
+                _buttonBinder.AddBinding(PageDownButton, PageDownButtonPressed);
+
+            _contentHeight = _contentRectTransform.rect.height;
+            _scrollPageHeight = _viewport.rect.height;
+            bool active = _contentHeight > _viewport.rect.height;
+            PageUpButton?.gameObject?.SetActive(active);
+            PageDownButton?.gameObject?.SetActive(active);
+            if (_verticalScrollIndicator != null)
+            {
+                _verticalScrollIndicator.gameObject.SetActive(active);
+                _verticalScrollIndicator.normalizedPageHeight = _viewport.rect.height / _contentHeight;
+            }
+            ComputeScrollFocusPosY();
+        }
+
+        public override void RefreshButtonsInteractibility()
+        {
+            if (PageUpButton != null)
+                PageUpButton.interactable = _dstPosY > 0f;
+            if (PageDownButton != null)
+                PageDownButton.interactable = _dstPosY < _contentHeight - _viewport.rect.height;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
@@ -98,7 +98,7 @@ namespace BeatSaberMarkupLanguage.Components
             bool active = _contentHeight > _viewport.rect.height;
             PageUpButton?.gameObject?.SetActive(active);
             PageDownButton?.gameObject?.SetActive(active);
-            RefreshBindings(); // TODO: somehow fix these bindings??? it doesn't seem to be reacting to the button presses
+            RefreshBindings();
             if (_verticalScrollIndicator != null)
             {
                 _verticalScrollIndicator.gameObject.SetActive(active);

--- a/BeatSaberMarkupLanguage/Components/NotifyUpdater.cs
+++ b/BeatSaberMarkupLanguage/Components/NotifyUpdater.cs
@@ -34,7 +34,7 @@ namespace BeatSaberMarkupLanguage.Components
                 OnDestroy();
                 return;
             }
-            PropertyInfo prop = sender.GetType().GetProperty(e.PropertyName);
+            PropertyInfo prop = sender.GetType().GetProperty(e.PropertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             Action<object> action = null;
             if (ActionDict.TryGetValue(e.PropertyName, out action))
                 action?.Invoke(prop.GetValue(sender));

--- a/BeatSaberMarkupLanguage/Macros/AsHostMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/AsHostMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -15,8 +16,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "host", new[]{"host"} },
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("host", out string host))
             {
                 if (!parserParams.values.TryGetValue(host, out BSMLValue value))

--- a/BeatSaberMarkupLanguage/Macros/BSMLMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/BSMLMacro.cs
@@ -19,6 +19,6 @@ namespace BeatSaberMarkupLanguage.Macros
             }
         }
         public abstract Dictionary<string, string[]> Props { get; }
-        public abstract void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams);
+        public abstract void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> childComponentTypes);
     }
 }

--- a/BeatSaberMarkupLanguage/Macros/DefineMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/DefineMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -16,8 +17,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "value", new[]{ "value" } }
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (!data.TryGetValue("name", out string name))
                 throw new Exception("define macro must have an id");
             if (!data.TryGetValue("value", out string value))

--- a/BeatSaberMarkupLanguage/Macros/ForEachMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/ForEachMacro.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using BeatSaberMarkupLanguage.Parser;
 using UnityEngine;
@@ -16,8 +17,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "passTags", new[]{"pass-back-tags"}}
         };
         
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("hosts", out string hosts))
             {
                 if (!parserParams.values.TryGetValue(hosts, out BSMLValue values))

--- a/BeatSaberMarkupLanguage/Macros/IfMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/IfMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -15,8 +16,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "value", new[]{"bool","value"} },
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("value", out string valueId))
             {
                 bool notOperator = false;
@@ -33,7 +35,8 @@ namespace BeatSaberMarkupLanguage.Macros
                 {
                     foreach (XmlNode childNode in node.ChildNodes)
                     {
-                        BSMLParser.instance.HandleNode(childNode, parent, parserParams);
+                        BSMLParser.instance.HandleNode(childNode, parent, parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> children);
+                        components = components.Concat(children);
                     }
                 }
             }

--- a/BeatSaberMarkupLanguage/Macros/ReparentMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/ReparentMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -16,8 +17,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "transforms", new[]{"transforms"} }
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("transform", out string transformId))
             {
                 if (!parserParams.values.TryGetValue(transformId, out BSMLValue value))

--- a/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
@@ -1,0 +1,47 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class ScrollIndicatorTag : BSMLTag
+    {
+        public override string[] Aliases { get; } = new[] { "vertical-scroll-indicator", "scroll-indicator" };
+
+        private static GameObject _verticalScrollTemplate = null;
+        public static GameObject VerticalScrollTemplate
+        {
+            get
+            {
+                if (_verticalScrollTemplate == null)
+                    _verticalScrollTemplate = Resources.FindObjectsOfTypeAll<VerticalScrollIndicator>().First().gameObject;
+
+                return _verticalScrollTemplate;
+            }
+        }
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameObject gameObject = Object.Instantiate(VerticalScrollTemplate);
+            gameObject.SetActive(false);
+            gameObject.name = "BSMLScrollIndicator";
+
+            RectTransform transform = gameObject.GetComponent<RectTransform>();
+            transform.SetParent(parent, false);
+
+            Object.Destroy(gameObject.GetComponent<VerticalScrollIndicator>());
+            BSMLScrollIndicator indicator = gameObject.AddComponent<BSMLScrollIndicator>();
+            indicator.Handle = transform.GetChild(0).GetComponent<RectTransform>();
+
+            gameObject.SetActive(true);
+            return gameObject;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
@@ -36,7 +36,7 @@ namespace BeatSaberMarkupLanguage.Tags
             RectTransform transform = gameObject.GetComponent<RectTransform>();
             transform.SetParent(parent, false);
 
-            Object.Destroy(gameObject.GetComponent<VerticalScrollIndicator>());
+            Object.DestroyImmediate(gameObject.GetComponent<VerticalScrollIndicator>());
             BSMLScrollIndicator indicator = gameObject.AddComponent<BSMLScrollIndicator>();
             indicator.Handle = transform.GetChild(0).GetComponent<RectTransform>();
 

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -19,6 +19,12 @@ namespace BeatSaberMarkupLanguage.Tags
             go.SetActive(false);
 
             RectTransform transform = go.AddComponent<RectTransform>();
+            transform.SetParent(parent, false);
+            transform.localPosition = Vector2.zero;
+            transform.anchorMin = Vector2.zero;
+            transform.anchorMax = Vector2.one;
+            transform.anchoredPosition = Vector2.zero;
+            transform.sizeDelta = Vector2.zero;
 
             GameObject vpgo = new GameObject("Viewport");
             RectTransform viewport = vpgo.AddComponent<RectTransform>();
@@ -44,9 +50,10 @@ namespace BeatSaberMarkupLanguage.Tags
             content.anchorMax = new Vector2(1f, 1f);
             content.anchoredPosition = Vector2.zero;
 
-            var contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
-            var contentFitter = contentgo.AddComponent<ContentSizeFitter>();
-            contentFitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            VerticalLayoutGroup contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
+            ContentSizeFitter contentFitter = contentgo.AddComponent<ContentSizeFitter>();
+            LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
+            contentFitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
             contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
             contentLayout.childControlHeight = true;
             contentLayout.childControlWidth = false;
@@ -54,6 +61,7 @@ namespace BeatSaberMarkupLanguage.Tags
             contentLayout.childForceExpandWidth = true;
             contentLayout.childAlignment = TextAnchor.UpperCenter;
             contentLayout.spacing = 0f;
+            layoutElement.preferredWidth = -1;
 
             BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();
             scrollView.ContentRect = content;

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -50,17 +50,11 @@ namespace BeatSaberMarkupLanguage.Tags
             content.anchorMax = new Vector2(1f, 1f);
             content.anchoredPosition = Vector2.zero;
 
-            VerticalLayoutGroup contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
             ContentSizeFitter contentFitter = contentgo.AddComponent<ContentSizeFitter>();
             LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
             contentFitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
             contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-            contentLayout.childControlHeight = true;
-            contentLayout.childControlWidth = false;
-            contentLayout.childForceExpandHeight = false;
-            contentLayout.childForceExpandWidth = true;
-            contentLayout.childAlignment = TextAnchor.UpperCenter;
-            contentLayout.spacing = 0f;
+            layoutElement.minWidth = -1;
             layoutElement.preferredWidth = -1;
 
             BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -49,13 +49,20 @@ namespace BeatSaberMarkupLanguage.Tags
             content.anchorMin = new Vector2(0f, 1f);
             content.anchorMax = new Vector2(1f, 1f);
             content.anchoredPosition = Vector2.zero;
+            content.pivot = new Vector2(0.5f, 1f);
 
             ContentSizeFitter contentFitter = contentgo.AddComponent<ContentSizeFitter>();
-            LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
             contentFitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
             contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            VerticalLayoutGroup layout = contentgo.AddComponent<VerticalLayoutGroup>();
+            layout.childControlHeight = false;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = false;
+            /*LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
             layoutElement.minWidth = -1;
             layoutElement.preferredWidth = -1;
+            layoutElement.flexibleWidth = 0;*/
+
 
             BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();
             scrollView.ContentRect = content;

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -1,0 +1,69 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class ScrollViewTag : BSMLTag
+    {
+        public override string[] Aliases { get; } = new[] { "scroll-view", "scroll" };
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameObject go = new GameObject("BSMLScrollView");
+            go.SetActive(false);
+
+            RectTransform transform = go.AddComponent<RectTransform>();
+
+            GameObject vpgo = new GameObject("Viewport");
+            RectTransform viewport = vpgo.AddComponent<RectTransform>();
+            viewport.SetParent(transform, false);
+            viewport.localPosition = Vector2.zero;
+            viewport.anchorMin = Vector2.zero;
+            viewport.anchorMax = Vector2.one;
+            viewport.anchoredPosition = Vector2.zero;
+            viewport.sizeDelta = Vector2.zero;
+
+            Mask vpmask = vpgo.AddComponent<Mask>();
+            Image vpimage = vpgo.AddComponent<Image>(); // a Mask needs an Image to work
+            vpmask.showMaskGraphic = false;
+            vpimage.color = Color.white;
+            vpimage.sprite = Utilities.ImageResources.WhitePixel;
+            vpimage.material = Utilities.ImageResources.NoGlowMat;
+
+            GameObject contentgo = new GameObject("Content Wrapper");
+            RectTransform content = contentgo.AddComponent<RectTransform>();
+            content.SetParent(viewport, false);
+            content.localPosition = Vector2.zero;
+            content.anchorMin = new Vector2(0f, 1f);
+            content.anchorMax = new Vector2(1f, 1f);
+            content.anchoredPosition = Vector2.zero;
+
+            var contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
+            var contentFitter = contentgo.AddComponent<ContentSizeFitter>();
+            contentFitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            contentLayout.childControlHeight = true;
+            contentLayout.childControlWidth = false;
+            contentLayout.childForceExpandHeight = false;
+            contentLayout.childForceExpandWidth = true;
+            contentLayout.childAlignment = TextAnchor.UpperCenter;
+            contentLayout.spacing = 0f;
+
+            BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();
+            scrollView.ContentRect = content;
+            scrollView.Viewport = viewport;
+
+            BSMLScrollViewContent contentType = contentgo.AddComponent<BSMLScrollViewContent>();
+            contentType.ScrollView = scrollView;
+
+            go.SetActive(true);
+            return contentgo;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollIndicatorHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollIndicatorHandler.cs
@@ -1,0 +1,40 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(BSMLScrollIndicator))]
+    public class ScrollIndicatorHandler : TypeHandler<BSMLScrollIndicator>
+    {
+        public override Dictionary<string, string[]> Props { get; }
+            = new Dictionary<string, string[]>
+            {
+                { "handleColor", new[] { "handle-color" } },
+                { "handleImage", new[] { "handle-image" } },
+            };
+
+        public override Dictionary<string, Action<BSMLScrollIndicator, string>> Setters { get; }
+            = new Dictionary<string, Action<BSMLScrollIndicator, string>>
+            {
+                { "handleColor", TrySetHandleColor },
+                { "handleImage", (indic, src) => GetHandleImage(indic).SetImage(src) },
+            };
+
+        private static Image GetHandleImage(BSMLScrollIndicator indicator) => indicator.Handle.GetComponent<Image>();
+        private static void TrySetHandleColor(BSMLScrollIndicator indicator, string colorString)
+        {
+            if (!ColorUtility.TryParseHtmlString(colorString, out Color color))
+            {
+                Logger.log.Warn($"String {colorString} not a valid color");
+                return;
+            }
+            GetHandleImage(indicator).color = color;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -29,14 +29,6 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             {
                 parserParams.AddEvent(id + "#PageUp", scrollView.PageUpButtonPressed);
                 parserParams.AddEvent(id + "#PageDown", scrollView.PageDownButtonPressed);
-
-                scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
-                    .Select(o => o.GetComponent<Button>())
-                    .FirstOrDefault(b => b != null);
-
-                scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
-                    .Select(o => o.GetComponent<Button>())
-                    .FirstOrDefault(b => b != null);
             }
 
             if (componentType.data.TryGetValue("maskOverflow", out string value))
@@ -53,6 +45,26 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             foreach (GameObject go in parserParams.GetObjectsWithTag("ScrollFocus"))
             {
                 go.AddComponent<ItemForFocussedScrolling>();
+            }
+        }
+
+        public override void HandleTypeAfterParse(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
+            BSMLScrollViewElement scrollView = content.ScrollView;
+
+            Logger.log.Debug("Handling scroll view after parse");
+
+            if (componentType.data.TryGetValue("id", out string id))
+            {
+                Logger.log.Debug($"Looking for buttons tagged for {id}");
+                scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
+
+                scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
             }
 
             scrollView.Setup();

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -17,6 +17,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         public override Dictionary<string, string[]> Props { get; } = new Dictionary<string, string[]>
         {
             { "id", new[]{ "id" } },
+            { "maskOverflow", new[] { "mask-overflow" } }
         };
 
         public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -37,6 +38,11 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                     .Select(o => o.GetComponent<Button>())
                     .FirstOrDefault(b => b != null);
             }
+
+            if (componentType.data.TryGetValue("maskOverflow", out string value))
+            {
+                scrollView.MaskOverflow = bool.TryParse(value, out bool bval) ? bval : true;
+            }
         }
 
         public override void HandleTypeAfterChildren(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -51,6 +57,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
             scrollView.Setup();
             scrollView.RefreshButtonsInteractibility();
+            scrollView.ScrollAt(0, false);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -37,7 +37,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                 scrollView.MaskOverflow = bool.TryParse(value, out bool bval) ? bval : true;
             }
 
-            if (componentType.data.TryGetValue("align-bottom", out value))
+            if (componentType.data.TryGetValue("alignBottom", out value))
             {
                 scrollView.AlignBottom = bool.TryParse(value, out bool bval) ? bval : false;
             }

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -45,9 +45,6 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
         public override void HandleTypeAfterChildren(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
         {
-            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
-            BSMLScrollViewElement scrollView = content.ScrollView;
-
             foreach (GameObject go in parserParams.GetObjectsWithTag("ScrollFocus"))
             {
                 go.AddComponent<ItemForFocussedScrolling>();
@@ -59,11 +56,8 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
             BSMLScrollViewElement scrollView = content.ScrollView;
 
-            Logger.log.Debug("Handling scroll view after parse");
-
             if (componentType.data.TryGetValue("id", out string id))
             {
-                Logger.log.Debug($"Looking for buttons tagged for {id}");
                 scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
                     .Select(o => o.GetComponent<Button>())
                     .FirstOrDefault(b => b != null);
@@ -71,6 +65,10 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                 scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
                     .Select(o => o.GetComponent<Button>())
                     .FirstOrDefault(b => b != null);
+
+                scrollView.ScrollIndicator = parserParams.GetObjectsWithTag("IndicatorFor:" + id)
+                    .Select(o => o.GetComponent<VerticalScrollIndicator>() ?? o.GetComponent<BSMLScrollIndicator>())
+                    .FirstOrDefault(i => i != null);
             }
 
             scrollView.Setup();

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -17,7 +17,8 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         public override Dictionary<string, string[]> Props { get; } = new Dictionary<string, string[]>
         {
             { "id", new[]{ "id" } },
-            { "maskOverflow", new[] { "mask-overflow" } }
+            { "maskOverflow", new[] { "mask-overflow" } },
+            { "alignBottom", new[] { "align-bottom" } },
         };
 
         public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -34,6 +35,11 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             if (componentType.data.TryGetValue("maskOverflow", out string value))
             {
                 scrollView.MaskOverflow = bool.TryParse(value, out bool bval) ? bval : true;
+            }
+
+            if (componentType.data.TryGetValue("align-bottom", out value))
+            {
+                scrollView.AlignBottom = bool.TryParse(value, out bool bval) ? bval : false;
             }
         }
 
@@ -69,7 +75,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
             scrollView.Setup();
             scrollView.RefreshButtonsInteractibility();
-            scrollView.ScrollAt(0, false);
+            //scrollView.ScrollAt(0, false);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -1,0 +1,56 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using BeatSaberMarkupLanguage.Parser;
+using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(BSMLScrollViewContent))]
+    public class ScrollViewHandler : TypeHandler
+    {
+        public override Dictionary<string, string[]> Props { get; } = new Dictionary<string, string[]>
+        {
+            { "id", new[]{ "id" } },
+        };
+
+        public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
+            BSMLScrollViewElement scrollView = content.ScrollView;
+
+            if (componentType.data.TryGetValue("id", out string id))
+            {
+                parserParams.AddEvent(id + "#PageUp", scrollView.PageUpButtonPressed);
+                parserParams.AddEvent(id + "#PageDown", scrollView.PageDownButtonPressed);
+
+                scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
+
+                scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
+            }
+        }
+
+        public override void HandleTypeAfterChildren(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
+            BSMLScrollViewElement scrollView = content.ScrollView;
+
+            foreach (GameObject go in parserParams.GetObjectsWithTag("ScrollFocus"))
+            {
+                go.AddComponent<ItemForFocussedScrolling>();
+            }
+
+            scrollView.Setup();
+            scrollView.RefreshButtonsInteractibility();
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/TypeHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/TypeHandler.cs
@@ -22,6 +22,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         public abstract Dictionary<string, string[]> Props { get; }
         public abstract void HandleType(ComponentTypeWithData componentType, BSMLParserParams parserParams);
         public virtual void HandleTypeAfterChildren(ComponentTypeWithData componentType, BSMLParserParams parserParams) { }
+        public virtual void HandleTypeAfterParse(ComponentTypeWithData componentType, BSMLParserParams parserParams) { }
     }
 
     public abstract class TypeHandler<T> : TypeHandler

--- a/BeatSaberMarkupLanguage/Utilities.cs
+++ b/BeatSaberMarkupLanguage/Utilities.cs
@@ -97,6 +97,7 @@ namespace BeatSaberMarkupLanguage
         {
             private static Material noGlowMat;
             private static Sprite _blankSprite = null;
+            private static Sprite _whitePixel = null;
 
             public static Material NoGlowMat
             {
@@ -120,6 +121,17 @@ namespace BeatSaberMarkupLanguage
                         _blankSprite = Sprite.Create(Texture2D.blackTexture, new Rect(), Vector2.zero);
 
                     return _blankSprite;
+                }
+            }
+
+            public static Sprite WhitePixel
+            {
+                get
+                {
+                    if (!_whitePixel)
+                        _whitePixel = Resources.FindObjectsOfTypeAll<Image>().First(i => i.sprite?.name == "WhitePixel").sprite;
+
+                    return _whitePixel;
                 }
             }
         }


### PR DESCRIPTION
This adds a new tag, `scroll` or `scroll-view`, that is extremely customizable by virtue of having its page buttons and scroll indicator separated, so that they can appear anywhere in the user's markup. It also adds a tag, `scroll-indicator` or `vertical-scroll-indicator`, which can act as a `scroll-view`'s scroll indicator, or as an indicator for anything else that can set its `progress` property.

---

Basic usage of `scroll-view` is as follows:
```xml
<scroll id='ScrollContent' size-delta-x='0'>
  <!-- content -->
</scroll>
```

This creates a scroll view whose viewport completely fills the containing element, fit for containing vertical content of any size. It should be noted that the attributes that apply to `RectTransform` apply to the content wrapper, and *not* to the viewport. Because the BSML architecture does not provide a reasonable way of dealing with this with only one tag, the viewport always completely fills the containing element by way of anchors at (0, 0) and (1, 1) with no size delta. It must, therefore, be wrapped in a `bg` element to allow control of the size and position of the viewport.

This alone does not provide page buttons, but those are simple to provide:
```xml
<bottom-button-panel>
  <button text='Page Up' tags='PageUpFor:ScrollContent' />
  <button text='Page Down' tags='PageDownFor:ScrollContent' />
</bottom-button-panel>
```
Simply by adding a tag of the form `PageUpFor:{id}` or `PageDownFor:{id}` to any button, the scroll view with the specified ID will find and manage those buttons. It will mark them intractable as appropriate, and if the scroll content is not large enough to need scrolling, it will disable them. Only the first button with the tag will be chosen for each.

`scroll-view` also listens for BSML events `{id}#PageUp` and `{id}#PageDown`, which then do the same things as the page buttons, but without the automatic management of intractability.

Objects that are tagged with `ScrollFocus` will be registered by the scroll view to attempt to focus its scrolling onto each object. There is no good way to explain this behaviour, it is simply something that should be experimented with, and may be useful for some circumstances.

You may also provide the attributes `mask-overflow` and `align-bottom`, both of which are booleans, to a `scroll-view`.

- `mask-overflow` indicates whether or not to mask out the content that is not under the viewport. Defaults to `true`, and should remain that way most of the time. Mostly useful for debugging rendering issues.
- `align-bottom` indicates whether or not to prefer to align content to the bottom of the viewport over the top. Defaults to `false`. Top-alignment is what is expected in most cases, however the option is present due mostly to the way it is implemented.

---

Basic usage of `scroll-indicator` is as follows:
```xml
<scroll-indicator tags='IndicatorFor:DescriptionWindow' />
```

Much like the page buttons, this can be associated with a `scroll-view` using a tag of the form `IndicatorFor:{id}`. It is also worth understanding that this does not have an intrinsic size, and therefore one must always be specified in some form. The indicator is always vertical, with the handle matching the width of the full indicator at all times, and sliding vertically along the indicator.

The handle may be customized using the attributes `handle-color` and `handle-image`:

- `handle-color` is a `Color`, and sets the `color` property of the `Image` on the handle object.
- `handle-image` represents the path to an image, and sets the image that will be rendered as the handle of the indicator.

The indicator itself also has an `Image` on it acting as its background, and the attributes that are associated with `Image`s may be used to control the color and content of the background of the indicator.

An indicator on its own does not do anything, and must be given to something else to drive its size and position.