### PR TITLE
Add system font management to BSML

### DIFF
--- a/BeatSaberMarkupLanguage/BSMLParser.cs
+++ b/BeatSaberMarkupLanguage/BSMLParser.cs
@@ -130,25 +130,33 @@ namespace BeatSaberMarkupLanguage
                 }
             }
 
+            IEnumerable<ComponentTypeWithData> componentInfo = Enumerable.Empty<ComponentTypeWithData>();
             foreach (XmlNode node in parentNode.ChildNodes)
-                HandleNode(node, parent, parserParams);
+            {
+                HandleNode(node, parent, parserParams, out IEnumerable<ComponentTypeWithData> components);
+                componentInfo = componentInfo.Concat(components);
+            }
 
             foreach (KeyValuePair<string, BSMLAction> action in parserParams.actions.Where(x => x.Key.StartsWith(SUBSCRIVE_EVENT_ACTION_PREFIX)))
                 parserParams.AddEvent(action.Key.Substring(1), delegate { action.Value.Invoke(); });
+
+            foreach (ComponentTypeWithData component in componentInfo)
+                component.typeHandler.HandleTypeAfterParse(component, parserParams);
 
             parserParams.EmitEvent("post-parse");
 
             return parserParams;
         }
 
-        public void HandleNode(XmlNode node, GameObject parent, BSMLParserParams parserParams)
+        public void HandleNode(XmlNode node, GameObject parent, BSMLParserParams parserParams, out IEnumerable<ComponentTypeWithData> componentInfo)
         {
+            componentInfo = Enumerable.Empty<ComponentTypeWithData>();
             if (node.Name.StartsWith(MACRO_PREFIX))
                 HandleMacroNode(node, parent, parserParams);
             else
-                HandleTagNode(node, parent, parserParams);
+                HandleTagNode(node, parent, parserParams, out componentInfo);
         }
-        private void HandleTagNode(XmlNode node, GameObject parent, BSMLParserParams parserParams)
+        private void HandleTagNode(XmlNode node, GameObject parent, BSMLParserParams parserParams, out IEnumerable<ComponentTypeWithData> componentInfo)
         {
 
             if (!tags.TryGetValue(node.Name, out BSMLTag currentTag))
@@ -194,14 +202,17 @@ namespace BeatSaberMarkupLanguage
             if (node.Attributes["tags"] != null)
                 parserParams.AddObjectTags(currentNode, node.Attributes["tags"].Value.Split(','));
 
+            IEnumerable<ComponentTypeWithData> childrenComponents = Enumerable.Empty<ComponentTypeWithData>();
             if (currentTag.AddChildren)
                 foreach (XmlNode childNode in node.ChildNodes)
-                    HandleNode(childNode, currentNode, parserParams);
+                    HandleNode(childNode, currentNode, parserParams, out childrenComponents);
 
             foreach (ComponentTypeWithData componentType in componentTypes)
             {
                 componentType.typeHandler.HandleTypeAfterChildren(componentType, parserParams);
             }
+
+            componentInfo = componentTypes.Concat(childrenComponents);
         }
 
         private Component GetExternalComponent(GameObject gameObject, Type type)

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>BSML</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>8.0</LangVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -168,6 +169,7 @@
     <Compile Include="Components\TextPageScrollViewRefresher.cs" />
     <Compile Include="FloatingScreen\FloatingScreen.cs" />
     <Compile Include="FloatingScreen\FloatingScreenMoverPointer.cs" />
+    <Compile Include="FontManager.cs" />
     <Compile Include="GameplaySetupTest.cs" />
     <Compile Include="GameplaySetup\GameplaySetup.cs" />
     <Compile Include="GameplaySetup\GameplaySetupMenu.cs" />
@@ -182,6 +184,17 @@
     <Compile Include="MenuButtons\MenuButton.cs" />
     <Compile Include="MenuButtons\MenuButtons.cs" />
     <Compile Include="Notify\INotifiableHost.cs" />
+    <Compile Include="OpenType\CollectionHeader.cs" />
+    <Compile Include="OpenType\NumericHelpers.cs" />
+    <Compile Include="OpenType\OffsetTable.cs" />
+    <Compile Include="OpenType\OpenTypeCollection.cs" />
+    <Compile Include="OpenType\OpenTypeCollectionReader.cs" />
+    <Compile Include="OpenType\OpenTypeFont.cs" />
+    <Compile Include="OpenType\OpenTypeFontReader.cs" />
+    <Compile Include="OpenType\OpenTypeReader.cs" />
+    <Compile Include="OpenType\OpenTypeTable.cs" />
+    <Compile Include="OpenType\OpenTypeTag.cs" />
+    <Compile Include="OpenType\TableRecord.cs" />
     <Compile Include="Parse.cs" />
     <Compile Include="Parser\BSMLAction.cs" />
     <Compile Include="BSMLParser.cs" />

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Attributes\UIValue.cs" />
     <Compile Include="Attributes\ViewDefinitionAttribute.cs" />
     <Compile Include="BeatSaberUI.cs" />
+    <Compile Include="Components\BSMLScrollIndicator.cs" />
     <Compile Include="Components\BSMLScrollView.cs" />
     <Compile Include="Components\BSMLScrollViewElement.cs" />
     <Compile Include="Components\BSMLScrollViewContent.cs" />
@@ -223,6 +224,7 @@
     <Compile Include="Tags\ModalTag.cs" />
     <Compile Include="Tags\PageButtonTag.cs" />
     <Compile Include="Tags\ScrollableSettingsContainerTag.cs" />
+    <Compile Include="Tags\ScrollIndicatorTag.cs" />
     <Compile Include="Tags\ScrollViewTag.cs" />
     <Compile Include="Tags\SettingsContainerTag.cs" />
     <Compile Include="Tags\Settings\BoolSettingTag.cs" />
@@ -267,6 +269,7 @@
     <Compile Include="TypeHandlers\ModalViewHandler.cs" />
     <Compile Include="TypeHandlers\PageButtonHandler.cs" />
     <Compile Include="TypeHandlers\RectTransformHandler.cs" />
+    <Compile Include="TypeHandlers\ScrollIndicatorHandler.cs" />
     <Compile Include="TypeHandlers\ScrollViewHandler.cs" />
     <Compile Include="TypeHandlers\Settings\DropDownListSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\GenericSettingHandler.cs" />

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -134,6 +134,8 @@
     <Compile Include="Attributes\ViewDefinitionAttribute.cs" />
     <Compile Include="BeatSaberUI.cs" />
     <Compile Include="Components\BSMLScrollView.cs" />
+    <Compile Include="Components\BSMLScrollViewElement.cs" />
+    <Compile Include="Components\BSMLScrollViewContent.cs" />
     <Compile Include="Components\BSMLTableView.cs" />
     <Compile Include="Components\ButtonArtworkImage.cs" />
     <Compile Include="Components\ButtonIconImage.cs" />
@@ -221,6 +223,7 @@
     <Compile Include="Tags\ModalTag.cs" />
     <Compile Include="Tags\PageButtonTag.cs" />
     <Compile Include="Tags\ScrollableSettingsContainerTag.cs" />
+    <Compile Include="Tags\ScrollViewTag.cs" />
     <Compile Include="Tags\SettingsContainerTag.cs" />
     <Compile Include="Tags\Settings\BoolSettingTag.cs" />
     <Compile Include="Tags\Settings\CheckboxSettingTag.cs" />
@@ -264,6 +267,7 @@
     <Compile Include="TypeHandlers\ModalViewHandler.cs" />
     <Compile Include="TypeHandlers\PageButtonHandler.cs" />
     <Compile Include="TypeHandlers\RectTransformHandler.cs" />
+    <Compile Include="TypeHandlers\ScrollViewHandler.cs" />
     <Compile Include="TypeHandlers\Settings\DropDownListSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\GenericSettingHandler.cs" />
     <Compile Include="TypeHandlers\Settings\IncrementSettingHandler.cs" />

--- a/BeatSaberMarkupLanguage/BeatSaberUI.cs
+++ b/BeatSaberMarkupLanguage/BeatSaberUI.cs
@@ -102,10 +102,10 @@ namespace BeatSaberMarkupLanguage
         /// </remarks>
         /// <param name="font">the Unity font to use</param>
         /// <returns>the new <see cref="TMP_FontAsset"/></returns>
-        public static TMP_FontAsset CreateTMPFont(Font font)
+        public static TMP_FontAsset CreateTMPFont(Font font, string nameOverride = null)
         {
             var tmpFont = TMP_FontAsset.CreateFontAsset(font);
-            tmpFont.SetName(font.name);
+            tmpFont.SetName(nameOverride ?? font.name);
             return tmpFont;
         }
 

--- a/BeatSaberMarkupLanguage/BeatSaberUI.cs
+++ b/BeatSaberMarkupLanguage/BeatSaberUI.cs
@@ -55,6 +55,56 @@ namespace BeatSaberMarkupLanguage
             return flow;
         }
 
+
+        private static TMP_FontAsset mainTextFont = null;
+        /// <summary>
+        /// Gets the main font used by the game for UI text.
+        /// </summary>
+        public static TMP_FontAsset MainTextFont
+            => mainTextFont ??= Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(t => t.name == "Teko-Medium SDF No Glow");
+
+        /// <summary>
+        /// Creates a clone of the given font, with its material fixed to be a no-glow material suitable for use on UI elements.
+        /// </summary>
+        /// <param name="font">the font to clone and fix</param>
+        /// <returns>the fixed clone</returns>
+        public static TMP_FontAsset CreateFixedUIFontClone(TMP_FontAsset font)
+        {
+            var matCopy = GameObject.Instantiate(MainTextFont.material);
+            matCopy.mainTexture = font.material.mainTexture;
+            matCopy.mainTextureOffset = font.material.mainTextureOffset;
+            matCopy.mainTextureScale = font.material.mainTextureScale;
+            var copy = GameObject.Instantiate(font);
+            copy.material = matCopy;
+            copy.SetName(font.name);
+            return copy;
+        }
+
+        /// <summary>
+        /// Sets the <c>name</c> of the font, recalculating its hash code as necessary.
+        /// </summary>
+        /// <param name="font">the font to modify</param>
+        /// <param name="name">the name to assign</param>
+        /// <returns>the <paramref name="name"/> provided</returns>
+        public static string SetName(this TMP_FontAsset font, string name)
+        {
+            font.name = name;
+            font.hashCode = TMP_TextUtilities.GetSimpleHashCode(font.name);
+            return name;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TMP_FontAsset"/> from a Unity <see cref="Font"/>.
+        /// </summary>
+        /// <param name="font">the Unity font to use</param>
+        /// <returns>the new <see cref="TMP_FontAsset"/></returns>
+        public static TMP_FontAsset CreateTMPFont(Font font)
+        {
+            var tmpFont = TMP_FontAsset.CreateFontAsset(font);
+            tmpFont.SetName(font.name);
+            return tmpFont;
+        }
+
         /// <summary>
         /// Creates a TextMeshProUGUI component.
         /// </summary>
@@ -81,7 +131,7 @@ namespace BeatSaberMarkupLanguage
             gameObj.SetActive(false);
 
             TextMeshProUGUI textMesh = gameObj.AddComponent<TextMeshProUGUI>();
-            textMesh.font = GameObject.Instantiate(Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(t => t.name == "Teko-Medium SDF No Glow"));
+            textMesh.font = MainTextFont;
             textMesh.rectTransform.SetParent(parent, false);
             textMesh.text = text;
             textMesh.fontSize = 4;

--- a/BeatSaberMarkupLanguage/BeatSaberUI.cs
+++ b/BeatSaberMarkupLanguage/BeatSaberUI.cs
@@ -96,6 +96,10 @@ namespace BeatSaberMarkupLanguage
         /// <summary>
         /// Creates a <see cref="TMP_FontAsset"/> from a Unity <see cref="Font"/>.
         /// </summary>
+        /// <remarks>
+        /// The <see cref="TMP_FontAsset"/> returned is not usable for UI text. Use <see cref="CreateFixedUIFontClone(TMP_FontAsset)"/>
+        /// to get a usable font.
+        /// </remarks>
         /// <param name="font">the Unity font to use</param>
         /// <returns>the new <see cref="TMP_FontAsset"/></returns>
         public static TMP_FontAsset CreateTMPFont(Font font)

--- a/BeatSaberMarkupLanguage/BeatSaberUI.cs
+++ b/BeatSaberMarkupLanguage/BeatSaberUI.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using Object = UnityEngine.Object;
 
 namespace BeatSaberMarkupLanguage
 {
@@ -70,14 +71,10 @@ namespace BeatSaberMarkupLanguage
         /// <returns>the fixed clone</returns>
         public static TMP_FontAsset CreateFixedUIFontClone(TMP_FontAsset font)
         {
-            var matCopy = GameObject.Instantiate(MainTextFont.material);
-            matCopy.mainTexture = font.material.mainTexture;
-            matCopy.mainTextureOffset = font.material.mainTextureOffset;
-            matCopy.mainTextureScale = font.material.mainTextureScale;
-            var copy = GameObject.Instantiate(font);
-            copy.material = matCopy;
-            copy.SetName(font.name);
-            return copy;
+            var noglowShader = MainTextFont.material.shader;
+            var newFont = Object.Instantiate(font);
+            newFont.material.shader = noglowShader;
+            return newFont;
         }
 
         /// <summary>

--- a/BeatSaberMarkupLanguage/BeatSaberUI.cs
+++ b/BeatSaberMarkupLanguage/BeatSaberUI.cs
@@ -61,7 +61,7 @@ namespace BeatSaberMarkupLanguage
         /// Gets the main font used by the game for UI text.
         /// </summary>
         public static TMP_FontAsset MainTextFont
-            => mainTextFont ??= Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(t => t.name == "Teko-Medium SDF No Glow");
+            => mainTextFont ??= Resources.FindObjectsOfTypeAll<TMP_FontAsset>().FirstOrDefault(t => t.name == "Teko-Medium SDF No Glow");
 
         /// <summary>
         /// Creates a clone of the given font, with its material fixed to be a no-glow material suitable for use on UI elements.

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollIndicator.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollIndicator.cs
@@ -1,0 +1,19 @@
+﻿using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class BSMLScrollIndicator : VerticalScrollIndicator
+    {
+        public RectTransform Handle
+        {
+            get => _handle;
+            set => _handle = value;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollViewContent.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollViewContent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class BSMLScrollViewContent : MonoBehaviour
+    {
+        public BSMLScrollViewElement ScrollView { get; set; }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
@@ -1,0 +1,81 @@
+﻿using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class BSMLScrollViewElement : ScrollView
+    {
+        public Button PageUpButton
+        {
+            get => _pageUpButton;
+            set => _pageUpButton = value;
+        }
+        public Button PageDownButton
+        {
+            get => _pageDownButton;
+            set => _pageDownButton = value;
+        }
+
+        public RectTransform Viewport
+        {
+            get => _viewport;
+            set => _viewport = value;
+        }
+
+        public RectTransform ContentRect
+        {
+            get => _contentRectTransform;
+            set => _contentRectTransform = value;
+        }
+
+        public VerticalScrollIndicator ScrollIndicator
+        {
+            get => _verticalScrollIndicator;
+            set => _verticalScrollIndicator = value;
+        }
+
+        public override void Awake()
+        {
+            _buttonBinder = new ButtonBinder();
+
+            Setup();
+            RefreshButtonsInteractibility();
+            enabled = false;
+        }
+
+        public override void Setup()
+        {
+            _buttonBinder.ClearBindings();
+            if (PageUpButton != null)
+                _buttonBinder.AddBinding(PageUpButton, PageUpButtonPressed);
+            if (PageDownButton != null)
+                _buttonBinder.AddBinding(PageDownButton, PageDownButtonPressed);
+
+            _contentHeight = _contentRectTransform.rect.height;
+            _scrollPageHeight = _viewport.rect.height;
+            bool active = _contentHeight > _viewport.rect.height;
+            PageUpButton?.gameObject?.SetActive(active);
+            PageDownButton?.gameObject?.SetActive(active);
+            if (_verticalScrollIndicator != null)
+            {
+                _verticalScrollIndicator.gameObject.SetActive(active);
+                _verticalScrollIndicator.normalizedPageHeight = _viewport.rect.height / _contentHeight;
+            }
+            ComputeScrollFocusPosY();
+        }
+
+        public override void RefreshButtonsInteractibility()
+        {
+            if (PageUpButton != null)
+                PageUpButton.interactable = _dstPosY > 0f;
+            if (PageDownButton != null)
+                PageDownButton.interactable = _dstPosY < _contentHeight - _viewport.rect.height;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollViewElement.cs
@@ -98,7 +98,7 @@ namespace BeatSaberMarkupLanguage.Components
             bool active = _contentHeight > _viewport.rect.height;
             PageUpButton?.gameObject?.SetActive(active);
             PageDownButton?.gameObject?.SetActive(active);
-            RefreshBindings(); // TODO: somehow fix these bindings??? it doesn't seem to be reacting to the button presses
+            RefreshBindings();
             if (_verticalScrollIndicator != null)
             {
                 _verticalScrollIndicator.gameObject.SetActive(active);

--- a/BeatSaberMarkupLanguage/Components/NotifyUpdater.cs
+++ b/BeatSaberMarkupLanguage/Components/NotifyUpdater.cs
@@ -34,7 +34,7 @@ namespace BeatSaberMarkupLanguage.Components
                 OnDestroy();
                 return;
             }
-            PropertyInfo prop = sender.GetType().GetProperty(e.PropertyName);
+            PropertyInfo prop = sender.GetType().GetProperty(e.PropertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             Action<object> action = null;
             if (ActionDict.TryGetValue(e.PropertyName, out action))
                 action?.Invoke(prop.GetValue(sender));

--- a/BeatSaberMarkupLanguage/FontManager.cs
+++ b/BeatSaberMarkupLanguage/FontManager.cs
@@ -1,0 +1,198 @@
+﻿using BeatSaberMarkupLanguage.OpenType;
+using IPA.Utilities.Async;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage
+{
+    public static class FontManager
+    {
+        private struct FontInfo
+        {
+            public string Path;
+            public OpenTypeFont Info;
+            public FontInfo(string path, OpenTypeFont info)
+            {
+                Path = path;
+                Info = info;
+            }
+        }
+
+        // family -> list of fonts in family
+        private static Dictionary<string, List<FontInfo>> fontInfoLookup;
+        // path -> loaded font object
+        private static readonly Dictionary<string, Font> loadedFontsCache = new Dictionary<string, Font>();
+
+        public static Task SystemFontLoadTask { get; private set; }
+
+        public static Task AsyncLoadSystemFonts()
+        {
+            if (IsInitialized) return Task.CompletedTask;
+            if (SystemFontLoadTask != null) return SystemFontLoadTask;
+            var task = Task.Factory.StartNew(LoadSystemFonts).Unwrap();
+            SystemFontLoadTask = task.ContinueWith(t =>
+            {
+                Logger.log.Debug("Font loading complete");
+                Interlocked.CompareExchange(ref fontInfoLookup, t.Result, null);
+                return Task.CompletedTask;
+            }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion);
+            task.ContinueWith(t => Logger.log.Error($"Font loading errored: {t.Exception}"), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnRanToCompletion);
+            return task;
+        }
+
+        public static Task Destroy()
+        {
+            fontInfoLookup = null;
+            return UnityMainThreadTaskScheduler.Factory.StartNew(() => DestroyDict(loadedFontsCache)).Unwrap()
+                .ContinueWith(_ => loadedFontsCache.Clear());
+        }
+
+        private static async Task DestroyDict(IReadOnlyDictionary<string, Font> dict)
+        {
+            foreach (var pair in dict)
+            {
+                Font.Destroy(pair.Value);
+                await Task.Yield(); // yield back to the scheduler to allow more things to happen
+            }
+        }
+
+        private static async Task<Dictionary<string, List<FontInfo>>> LoadSystemFonts()
+        {
+            var paths = Font.GetPathsToOSFonts();
+
+            var fonts = new Dictionary<string, List<FontInfo>>(paths.Length, StringComparer.InvariantCultureIgnoreCase);
+
+            foreach (var path in paths)
+            {
+                try
+                {
+                    AddFontFileToCache(fonts, path);
+                }
+                catch (Exception e)
+                {
+                    Logger.log.Error(e);
+                }
+
+                await Task.Yield();
+            }
+
+            return fonts;
+        }
+
+        private static IEnumerable<OpenTypeFont> AddFontFileToCache(Dictionary<string, List<FontInfo>> cache, string path)
+        {
+            void AddFont(OpenTypeFont font)
+            {
+#if DEBUG
+                Logger.log.Debug($"'{path}' = '{font.Family}' '{font.Subfamily}' ({font.FullName})");
+#endif
+                var list = GetListForFamily(cache, font.Family);
+                list.Add(new FontInfo(path, font));
+            }
+
+            using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var reader = OpenTypeReader.For(fileStream);
+            if (reader is OpenTypeCollectionReader colReader)
+            {
+                var collection = new OpenTypeCollection(colReader, lazyLoad: false);
+                foreach (var font in collection)
+                    AddFont(font);
+                return collection;
+            }
+            else if (reader is OpenTypeFontReader fontReader)
+            {
+                var font = new OpenTypeFont(fontReader, lazyLoad: false);
+                AddFont(font);
+                return Utilities.SingleEnumerable(font);
+            }
+            else
+            {
+                Logger.log.Warn($"Font file '{path}' is not an OpenType file");
+                return Enumerable.Empty<OpenTypeFont>();
+            }
+        }
+
+        private static List<FontInfo> GetListForFamily(Dictionary<string, List<FontInfo>> cache, string family)
+        {
+            if (!cache.TryGetValue(family, out var list))
+                cache.Add(family, list = new List<FontInfo>());
+            return list;
+        }
+
+        public static Font AddFileToCache(string path)
+        {
+            ThrowIfNotInitialized();
+
+            lock (fontInfoLookup)
+            {
+                var set = AddFontFileToCache(fontInfoLookup, path);
+                if (!set.Any())
+                    throw new ArgumentException("File is not an OpenType font or collection", nameof(path));
+                return GetFontFromCacheOrLoad(new FontInfo(path, set.First()));
+            }
+        }
+
+        public static bool IsInitialized => fontInfoLookup != null;
+
+        private static void ThrowIfNotInitialized()
+        {
+            if (!IsInitialized) throw new InvalidOperationException("FontManager not initialized");
+        }
+
+        public static bool TryGetFont(string family, out Font font, string subfamily = null, bool fallbackIfNoSubfamily = false)
+        {
+            ThrowIfNotInitialized();
+
+            if (subfamily == null) fallbackIfNoSubfamily = true;
+            subfamily ??= "Regular"; // this is a typical default family name
+
+            lock (fontInfoLookup)
+            {
+                if (fontInfoLookup.TryGetValue(family, out var fonts))
+                {
+                    var info = fonts.AsNullable().FirstOrDefault(p => p?.Info.Subfamily == subfamily);
+                    if (info == null)
+                    {
+                        if (!fallbackIfNoSubfamily)
+                        {
+                            font = null;
+                            return false;
+                        }
+                        else
+                        {
+                            info = fonts.First();
+                        }
+                    }
+
+                    font = GetFontFromCacheOrLoad(info.Value);
+                    return true;
+                }
+                else
+                {
+                    font = null;
+                    return false;
+                }
+            }
+        }
+
+        private static Font GetFontFromCacheOrLoad(FontInfo info)
+        {
+            lock (loadedFontsCache)
+            {
+                if (!loadedFontsCache.TryGetValue(info.Path, out var font))
+                {
+                    font = new Font(info.Path);
+                    font.name = info.Info.FullName;
+                    loadedFontsCache.Add(info.Path, font);
+                }
+                return font;
+            }
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/FontManager.cs
+++ b/BeatSaberMarkupLanguage/FontManager.cs
@@ -365,7 +365,7 @@ namespace BeatSaberMarkupLanguage
             var font = GetFontFromCacheOrLoad(info);
             if (!tmpFontCache.TryGetValue((font, setupOsFallbacks), out var tmpFont))
             {
-                tmpFont = BeatSaberUI.CreateTMPFont(font);
+                tmpFont = BeatSaberUI.CreateTMPFont(font, info.Info.FullName);
 
                 if (setupOsFallbacks)
                 {

--- a/BeatSaberMarkupLanguage/FontManager.cs
+++ b/BeatSaberMarkupLanguage/FontManager.cs
@@ -61,7 +61,7 @@ namespace BeatSaberMarkupLanguage
                 return Task.CompletedTask;
             }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion).Unwrap();
             task.ContinueWith(t => Logger.log.Error($"Font loading errored: {t.Exception}"), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnRanToCompletion);
-            return task;
+            return SystemFontLoadTask;
         }
 
         internal static Task Destroy()
@@ -376,6 +376,8 @@ namespace BeatSaberMarkupLanguage
                         Logger.log.Debug($"Reading fallback '{fallback}'");
                         if (TryGetTMPFontByFullName(fallback, out var fallbackFont, false))
                         {
+                            if (tmpFont.fallbackFontAssetTable == null)
+                                tmpFont.fallbackFontAssetTable = new List<TMP_FontAsset>();
                             tmpFont.fallbackFontAssetTable.Add(fallbackFont);
                         }
                         else

--- a/BeatSaberMarkupLanguage/Macros/AsHostMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/AsHostMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -15,8 +16,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "host", new[]{"host"} },
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("host", out string host))
             {
                 if (!parserParams.values.TryGetValue(host, out BSMLValue value))

--- a/BeatSaberMarkupLanguage/Macros/BSMLMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/BSMLMacro.cs
@@ -19,6 +19,6 @@ namespace BeatSaberMarkupLanguage.Macros
             }
         }
         public abstract Dictionary<string, string[]> Props { get; }
-        public abstract void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams);
+        public abstract void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> childComponentTypes);
     }
 }

--- a/BeatSaberMarkupLanguage/Macros/DefineMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/DefineMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -16,8 +17,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "value", new[]{ "value" } }
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (!data.TryGetValue("name", out string name))
                 throw new Exception("define macro must have an id");
             if (!data.TryGetValue("value", out string value))

--- a/BeatSaberMarkupLanguage/Macros/ForEachMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/ForEachMacro.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using BeatSaberMarkupLanguage.Parser;
 using UnityEngine;
@@ -16,8 +17,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "passTags", new[]{"pass-back-tags"}}
         };
         
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("hosts", out string hosts))
             {
                 if (!parserParams.values.TryGetValue(hosts, out BSMLValue values))

--- a/BeatSaberMarkupLanguage/Macros/IfMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/IfMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -15,8 +16,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "value", new[]{"bool","value"} },
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("value", out string valueId))
             {
                 bool notOperator = false;
@@ -33,7 +35,8 @@ namespace BeatSaberMarkupLanguage.Macros
                 {
                     foreach (XmlNode childNode in node.ChildNodes)
                     {
-                        BSMLParser.instance.HandleNode(childNode, parent, parserParams);
+                        BSMLParser.instance.HandleNode(childNode, parent, parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> children);
+                        components = components.Concat(children);
                     }
                 }
             }

--- a/BeatSaberMarkupLanguage/Macros/ReparentMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/ReparentMacro.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using UnityEngine;
 
@@ -16,8 +17,9 @@ namespace BeatSaberMarkupLanguage.Macros
             { "transforms", new[]{"transforms"} }
         };
 
-        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams)
+        public override void Execute(XmlNode node, GameObject parent, Dictionary<string, string> data, BSMLParserParams parserParams, out IEnumerable<BSMLParser.ComponentTypeWithData> components)
         {
+            components = Enumerable.Empty<BSMLParser.ComponentTypeWithData>();
             if (data.TryGetValue("transform", out string transformId))
             {
                 if (!parserParams.values.TryGetValue(transformId, out BSMLValue value))

--- a/BeatSaberMarkupLanguage/OpenType/CollectionHeader.cs
+++ b/BeatSaberMarkupLanguage/OpenType/CollectionHeader.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public struct CollectionHeader
+    {
+        public static readonly OpenTypeTag TTCExpectedTag = OpenTypeTag.FromString("ttcf");
+        public const uint TTCTagBEInt = 0x74746366;
+
+        public OpenTypeTag TTCTag { get; set; }
+        public ushort MajorVersion { get; set; }
+        public ushort MinorVersion { get; set; }
+        public uint NumFonts { get; set; }
+        public uint[] OffsetTable { get; set; }
+
+        public const uint DSIGTagValue = 0x44534947;
+        public uint DSIGTag { get; set; }
+        public uint DSIGLength { get; set; }
+        public uint DSIGOffset { get; set; }
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/NumericHelpers.cs
+++ b/BeatSaberMarkupLanguage/OpenType/NumericHelpers.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public static class NumericHelpers
+    {
+        public static uint Log2(uint x)
+        {
+            x |= (x >> 1);
+            x |= (x >> 2);
+            x |= (x >> 4);
+            x |= (x >> 8);
+            x |= (x >> 16);
+
+            return (uint)(NumBitsSet(x) - 1);
+        }
+
+        public static uint NextPow2(uint x)
+        {
+            x |= (x >> 1);
+            x |= (x >> 2);
+            x |= (x >> 4);
+            x |= (x >> 8);
+            x |= (x >> 16);
+
+            return x + 1;
+        }
+
+        public static int NumBitsSet(uint x)
+        {
+            x -= ((x >> 1) & 0x55555555);
+            x = (((x >> 2) & 0x33333333) + (x & 0x33333333));
+            x = (((x >> 4) + x) & 0x0f0f0f0f);
+            x += (x >> 8);
+            x += (x >> 16);
+
+            return (int)(x & 0x0000003f);
+        }
+
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OffsetTable.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OffsetTable.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public struct OffsetTable
+    {
+        public const uint TrueTypeOnlyVersion = 0x00010000;
+        public const uint OpenTypeCFFVersion = 0x4F54544F;
+
+        public uint SFNTVersion { get; set; }
+        public ushort NumTables { get; set; }
+        /// <summary>
+        /// (Maximum power of 2 <= numTables) x 16.
+        /// </summary>
+        public ushort SearchRange { get; set; }
+        /// <summary>
+        /// Log2(maximum power of 2 <= numTables).
+        /// </summary>
+        public ushort EntrySelector { get; set; }
+        /// <summary>
+        /// NumTables x 16-searchRange.
+        /// </summary>
+        public ushort RangeShift { get; set; }
+
+        public long TablesStart { get; set; }
+
+        public bool Validate()
+        {
+            var powLessNumTables = NumericHelpers.NextPow2(NumTables) << 1;
+            if (SearchRange != (ushort)powLessNumTables * 16)
+                return false;
+            if (EntrySelector != (ushort)NumericHelpers.Log2(powLessNumTables))
+                return false;
+            if (RangeShift != NumTables * 16 - SearchRange)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeCollection.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeCollection.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public class OpenTypeCollection : IEnumerable<OpenTypeFont>, IDisposable
+    {
+        private readonly CollectionHeader header;
+        private OpenTypeFont[] fonts;
+        private readonly bool lazy;
+
+        public OpenTypeCollectionReader Reader { get; }
+
+        public OpenTypeCollection(OpenTypeCollectionReader reader, bool lazyLoad = true) : this(reader.ReadCollectionHeader(), reader, lazyLoad)
+        {
+        }
+        public OpenTypeCollection(CollectionHeader header, OpenTypeCollectionReader reader, bool lazyLoad = true)
+        {
+            this.header = header;
+            lazy = lazyLoad;
+            if (lazyLoad)
+                Reader = reader;
+            else
+                LoadAll(reader);
+        }
+
+        private void LoadAll(OpenTypeCollectionReader reader)
+        {
+            fonts = ReadFonts(reader);
+        }
+
+        public IEnumerable<OpenTypeFont> Fonts
+            => fonts ??= ReadFonts(Reader);
+
+        private OpenTypeFont[] ReadFonts(OpenTypeCollectionReader reader)
+            => reader.ReadFonts(header, lazy);
+
+        public IEnumerator<OpenTypeFont> GetEnumerator()
+            => Fonts.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => Fonts.GetEnumerator();
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~OpenTypeCollection()
+        // {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeCollectionReader.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeCollectionReader.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public class OpenTypeCollectionReader : OpenTypeFontReader
+    {
+        public OpenTypeCollectionReader(Stream input) : base(input)
+        {
+        }
+
+        public OpenTypeCollectionReader(Stream input, Encoding encoding) : base(input, encoding)
+        {
+        }
+
+        public OpenTypeCollectionReader(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen)
+        {
+        }
+
+        public CollectionHeader ReadCollectionHeader()
+        {
+            var header = new CollectionHeader
+            {
+                TTCTag = ReadTag(),
+                MajorVersion = ReadUInt16(),
+                MinorVersion = ReadUInt16(),
+                NumFonts = ReadUInt32(),
+            };
+            header.OffsetTable = new uint[header.NumFonts];
+            for (uint i = 0; i < header.NumFonts; i++)
+                header.OffsetTable[i] = ReadOffset32();
+
+            if (header.MajorVersion == 2)
+            {
+                header.DSIGTag = ReadUInt32();
+                header.DSIGLength = ReadUInt32();
+                header.DSIGOffset = ReadUInt32();
+            }
+
+            return header;
+        }
+
+        public OffsetTable[] ReadOffsetTables(CollectionHeader header)
+        {
+            var tables = new OffsetTable[header.NumFonts];
+            for (uint i = 0; i < header.NumFonts; i++)
+            {
+                BaseStream.Position = header.OffsetTable[i];
+                tables[i] = ReadOffsetTable();
+            }
+            return tables;
+        }
+
+        public OpenTypeFont[] ReadFonts(CollectionHeader header, bool lazyLoad = true)
+        {
+            var fonts = new OpenTypeFont[header.NumFonts];
+            for (uint i = 0; i < header.NumFonts; i++)
+            {
+                BaseStream.Position = header.OffsetTable[i];
+                fonts[i] = new OpenTypeFont(this, lazyLoad);
+            }
+            return fonts;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeFont.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeFont.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public class OpenTypeFont : IDisposable
+    {
+        private readonly OffsetTable offsetTable;
+
+        private readonly TableRecord[] tables;
+        private readonly TableRecord? nameTableRecord;
+
+        public OpenTypeFontReader Reader { get; }
+
+        public OpenTypeFont(OpenTypeFontReader reader, bool lazyLoad = true) : this(reader.ReadOffsetTable(), reader, lazyLoad)
+        {
+        }
+
+        public OpenTypeFont(OffsetTable offsets, OpenTypeFontReader reader, bool lazyLoad = true)
+        {
+            offsetTable = offsets;
+            tables = reader.ReadTableRecords(offsetTable);
+            nameTableRecord = tables.Select(t => new TableRecord?(t))
+                .FirstOrDefault(t => t.Value.TableTag == OpenTypeTag.NAME);
+
+            if (lazyLoad)
+                Reader = reader;
+            else
+                LoadAllTables(reader);
+        }
+
+        private void LoadAllTables(OpenTypeFontReader reader)
+        {
+            nameTable = ReadNameTable(reader);
+            // TODO: do something with this
+        }
+
+        private OpenTypeNameTable nameTable = null;
+        public OpenTypeNameTable NameTable
+            => nameTable ??= ReadNameTable(Reader);
+
+        private string uniqueId = null;
+        public string UniqueId
+            => uniqueId ??= FindBestNameRecord(OpenTypeNameTable.NameRecord.NameType.UniqueId)?.Value;
+
+        private string family = null;
+        public string Family
+            => family ??= FindBestNameRecord(OpenTypeNameTable.NameRecord.NameType.FontFamily)?.Value;
+
+        private string subfamily = null;
+        public string Subfamily
+            => subfamily ??= FindBestNameRecord(OpenTypeNameTable.NameRecord.NameType.FontSubfamily)?.Value;
+
+        private string fullName = null;
+        public string FullName
+            => fullName ??= FindBestNameRecord(OpenTypeNameTable.NameRecord.NameType.FullFontName)?.Value;
+
+        private OpenTypeNameTable ReadNameTable(OpenTypeFontReader reader)
+            => reader.TryReadTable(nameTableRecord.Value) as OpenTypeNameTable;
+
+        private OpenTypeNameTable.NameRecord FindBestNameRecord(OpenTypeNameTable.NameRecord.NameType type)
+        {
+            static int RankPlatform(OpenTypeNameTable.NameRecord record)
+                => record.PlatformID switch
+                {
+                    OpenTypeNameTable.NameRecord.Platform.Windows => 3000,
+                    OpenTypeNameTable.NameRecord.Platform.Unicode => 2000,
+                    OpenTypeNameTable.NameRecord.Platform.Macintosh => 1000,
+                    _ => 0,
+                };
+            static int RankLanguage(OpenTypeNameTable.NameRecord record)
+                => record switch
+                {
+                    { // because i'm a stupid little bitch i prefer US English
+                        PlatformID: OpenTypeNameTable.NameRecord.Platform.Windows,
+                        LanguageID: OpenTypeNameTable.NameRecord.USEnglishLangID
+                    } => 100,
+                    _ => 0,
+                };
+
+            return NameTable.NameRecords.Where(r => r.NameID == type)
+                .OrderByDescending(r => RankPlatform(r) + RankLanguage(r))
+                .FirstOrDefault();
+        }
+
+        public IEnumerable<TableRecord> Tables => tables;
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Reader?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~OpenTypeFont()
+        // {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeFontReader.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeFontReader.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+
+    // TODO: this shit is a mess, clean it up
+    public class OpenTypeFontReader : OpenTypeReader
+    {
+        public OpenTypeFontReader(Stream input) : base(input)
+        {
+        }
+
+        public OpenTypeFontReader(Stream input, Encoding encoding) : base(input, encoding)
+        {
+        }
+
+        public OpenTypeFontReader(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen)
+        {
+        }
+
+        public OffsetTable ReadOffsetTable()
+            => new OffsetTable()
+            {
+                SFNTVersion = ReadUInt32(),
+                NumTables = ReadUInt16(),
+                SearchRange = ReadUInt16(),
+                EntrySelector = ReadUInt16(),
+                RangeShift = ReadUInt16(),
+                TablesStart = BaseStream.Position,
+            };
+
+        protected TableRecord ReadTableRecord()
+            => new TableRecord()
+            {
+                TableTag = ReadTag(),
+                Checksum = ReadUInt32(),
+                Offset = ReadOffset32(),
+                Length = ReadUInt32()
+            };
+
+        public TableRecord[] ReadTableRecords(OffsetTable offsets)
+        { 
+            BaseStream.Position = offsets.TablesStart;
+            var tables = new TableRecord[offsets.NumTables];
+            for (int i = 0; i < offsets.NumTables; i++)
+                tables[i] = ReadTableRecord();
+            return tables;
+        }
+
+        public TableRecord[] ReadAllTables() => ReadTableRecords(ReadOffsetTable());
+
+        public OpenTypeTable TryReadTable(TableRecord table)
+        {
+            BaseStream.Position = table.Offset;
+
+            OpenTypeTable result = null;
+            if (table.TableTag == OpenTypeTag.NAME)
+                result = new OpenTypeNameTable();
+
+            result?.ReadFrom(this, table.Length);
+
+            return result;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeReader.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeReader.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public abstract class OpenTypeReader : BinaryReader
+    {
+        protected OpenTypeReader(Stream input) : base(input)
+        {
+        }
+
+        protected OpenTypeReader(Stream input, Encoding encoding) : base(input, encoding)
+        {
+        }
+
+        protected OpenTypeReader(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen)
+        {
+        }
+
+        public static byte[] FromBigEndian(byte[] bytes)
+        {
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(bytes);
+            return bytes;
+        }
+
+        public byte ReadUInt8() => ReadByte();
+        public sbyte ReadInt8() => ReadSByte();
+        public new ushort ReadUInt16()
+            => BitConverter.ToUInt16(FromBigEndian(ReadBytes(2)), 0);
+        public new short ReadInt16()
+            => BitConverter.ToInt16(FromBigEndian(ReadBytes(2)), 0);
+        public new uint ReadUInt32()
+            => BitConverter.ToUInt32(FromBigEndian(ReadBytes(4)), 0);
+        public new int ReadInt32()
+            => BitConverter.ToInt32(FromBigEndian(ReadBytes(4)), 0);
+
+        public int ReadFixed() => ReadInt32();
+
+        public short ReadFWord() => ReadInt16();
+        public ushort ReadUFWord() => ReadUInt16();
+
+        public short ReadF2Dot14() => ReadInt16();
+
+        public long ReadLongDateTime()
+            => BitConverter.ToInt64(FromBigEndian(ReadBytes(8)), 0);
+
+        public OpenTypeTag ReadTag() => new OpenTypeTag(ReadBytes(4));
+
+        public ushort ReadOffset16() => ReadUInt16();
+        public uint ReadOffset32() => ReadUInt32();
+
+
+        public static OpenTypeReader For(Stream stream, Encoding enc = null, bool leaveOpen = false)
+        {
+            enc ??= Encoding.Default;
+
+            var start = stream.Position;
+            using var reader = new BinaryReader(stream, enc, true);
+            var tag = BitConverter.ToUInt32(FromBigEndian(reader.ReadBytes(4)), 0);
+            stream.Position = start;
+
+            return tag switch
+            {
+                CollectionHeader.TTCTagBEInt => new OpenTypeCollectionReader(stream, enc, leaveOpen),
+                OffsetTable.OpenTypeCFFVersion => new OpenTypeFontReader(stream, enc, leaveOpen),
+                OffsetTable.TrueTypeOnlyVersion => new OpenTypeFontReader(stream, enc, leaveOpen),
+                _ => null
+            };
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeTable.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeTable.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public abstract class OpenTypeTable
+    {
+        public abstract void ReadFrom(OpenTypeReader reader, uint length);
+    }
+
+    public class OpenTypeNameTable : OpenTypeTable
+    {
+        public enum FormatEnum : ushort
+        {
+            Default = 0, LangTagged = 1
+        }
+
+        public FormatEnum Format { get; private set; }
+
+        public ushort Count { get; private set; }
+        /// <summary>
+        /// Offset to start of string storage from table start
+        /// </summary>
+        public ushort StringOffset { get; private set; }
+        public IReadOnlyList<NameRecord> NameRecords { get; private set; }
+
+        public ushort LangTagCount { get; private set; } = 0;
+        public IReadOnlyList<LangTagRecord> LangTagRecords { get; private set; } = new List<LangTagRecord>();
+
+        public override void ReadFrom(OpenTypeReader reader, uint length)
+        {
+            Format = (FormatEnum)reader.ReadUInt16();
+            Count = reader.ReadUInt16();
+            StringOffset = reader.ReadUInt16();
+            uint seekOffset = (uint)StringOffset - 6;
+            NameRecords = ReadNameRecords(reader);
+            seekOffset -= Count * NameRecord.Size;
+            if (Format == FormatEnum.LangTagged)
+            {
+                LangTagCount = reader.ReadUInt16();
+                seekOffset -= 2;
+                LangTagRecords = ReadLangTagRecords(reader);
+                seekOffset -= LangTagCount * LangTagRecord.Size;
+            }
+
+            reader.BaseStream.Seek(seekOffset, SeekOrigin.Current);
+            var startBase = reader.BaseStream.Position;
+
+
+            foreach (var name in NameRecords)
+            {
+                reader.BaseStream.Position = startBase + name.Offset;
+                var nameBytes = reader.ReadBytes(name.Length);
+
+                // TODO: maybe know how to identify more platforms and encodings?
+                if (name.PlatformID == NameRecord.Platform.Windows || name.PlatformID == NameRecord.Platform.Unicode)
+                {
+                    name.Value = Encoding.BigEndianUnicode.GetString(nameBytes);
+                }
+                else
+                {
+                    // hope and pray that the encoding is always UTF-8
+                    name.Value = Encoding.UTF8.GetString(nameBytes);
+                }
+            }
+
+            foreach (var langTag in LangTagRecords)
+            {
+                reader.BaseStream.Position = startBase + langTag.Offset;
+                var nameBytes = reader.ReadBytes(langTag.Length);
+
+                // hope and pray that the encoding is always UTF-8
+                langTag.Value = Encoding.UTF8.GetString(nameBytes);
+            }
+        }
+
+        // uses Count to read them
+        private IReadOnlyList<NameRecord> ReadNameRecords(OpenTypeReader reader)
+        {
+            var list = new List<NameRecord>();
+            for (int i = 0; i < Count; i++)
+            {
+                list.Add(new NameRecord
+                {
+                    PlatformID = (NameRecord.Platform)reader.ReadUInt16(),
+                    EncodingID = reader.ReadUInt16(),
+                    LanguageID = reader.ReadUInt16(),
+                    NameID = (NameRecord.NameType)reader.ReadUInt16(),
+                    Length = reader.ReadUInt16(),
+                    Offset = reader.ReadOffset16()
+                });
+            }
+            return list;
+        }
+
+        public class NameRecord
+        {
+            public const uint Size = 12;
+            public const ushort USEnglishLangID = 0x0409;
+
+            public enum Platform : ushort
+            {
+                Unicode = 0, Macintosh = 1, ISO = 2,
+                Windows = 3, Custom = 4
+            }
+
+            public Platform PlatformID { get; set; }
+
+            public ushort EncodingID { get; set; }
+            public ushort LanguageID { get; set; }
+
+            public enum NameType : ushort
+            {
+                Copyright = 0, FontFamily = 1, FontSubfamily = 2,
+                UniqueId = 3, FullFontName = 4, Version = 5,
+                PostScriptName = 6, Trademark = 7, Manufacturer = 8,
+                Designer = 9, Description = 10, VendorURL = 11,
+                DesignerURL = 12, LicenseDescription = 13,
+                LicenseInfoURL = 14, Reserved1 = 15,
+                TypographicFamily = 16,
+                TypographicSubfamily = 17,
+                /// <summary>
+                /// This is a Macintosh only field.
+                /// </summary>
+                CompatibleFull = 18,
+                SampleText = 19, PostScriptCID = 20,
+                WWSFamily = 21, WWSSubfamily = 22,
+                LightBackgroundPalette = 23,
+                DarkBackgroundPalette = 24,
+                VariationsPostScriptPrefix = 25,
+            }
+
+            public NameType NameID { get; set; }
+            public ushort Length { get; set; }
+            public ushort Offset { get; set; }
+
+            public string Value { get; set; }
+        }
+
+        // uses LangTagCount to read them
+        private IReadOnlyList<LangTagRecord> ReadLangTagRecords(OpenTypeReader reader)
+        {
+            var list = new List<LangTagRecord>();
+            for (int i = 0; i < LangTagCount; i++)
+            {
+                list.Add(new LangTagRecord
+                {
+                    Length = reader.ReadUInt16(),
+                    Offset = reader.ReadOffset16()
+                });
+            }
+            return list;
+        }
+
+        public class LangTagRecord
+        {
+            public const uint Size = 4;
+            public ushort Length { get; set; }
+            /// <summary>
+            /// string offset from start of storage area
+            /// </summary>
+            public ushort Offset { get; set; }
+
+            public string Value { get; set; }
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/OpenTypeTag.cs
+++ b/BeatSaberMarkupLanguage/OpenType/OpenTypeTag.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public struct OpenTypeTag
+    {
+        public static readonly OpenTypeTag NAME = FromString("name");
+
+        public byte[] Value { get; set; }
+        public uint IntValue => BitConverter.ToUInt32(Value, 0);
+
+        public bool Validate()
+            => Value.Length == 4 && Value.All(b => b >= 0x20 && b <= 0x7E);
+
+        public override bool Equals(object obj)
+            => obj is OpenTypeTag tag && IntValue == tag.IntValue;
+
+        public override int GetHashCode()
+            => 1637310455 + IntValue.GetHashCode();
+
+        public OpenTypeTag(byte[] value) => Value = value;
+
+        public static OpenTypeTag FromChars(char[] chrs)
+            => new OpenTypeTag(chrs.Select(c => (byte)c).ToArray());
+        public static OpenTypeTag FromString(string str)
+            => FromChars(str.ToCharArray(0, 4));
+
+        public static bool operator ==(OpenTypeTag left, OpenTypeTag right)
+            => left.Equals(right);
+
+        public static bool operator !=(OpenTypeTag left, OpenTypeTag right)
+            => !(left == right);
+    }
+}

--- a/BeatSaberMarkupLanguage/OpenType/TableRecord.cs
+++ b/BeatSaberMarkupLanguage/OpenType/TableRecord.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberMarkupLanguage.OpenType
+{
+    public struct TableRecord
+    {
+        public OpenTypeTag TableTag { get; set; }
+        public uint Checksum { get; set; }
+        /// <summary>
+        /// Offset from the beginning of the file.
+        /// </summary>
+        public uint Offset { get; set; }
+        public uint Length { get; set; }
+
+        public bool Validate() => TableTag.Validate();
+    }
+}

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -60,7 +60,7 @@ namespace BeatSaberMarkupLanguage
                         yield return new WaitUntil(() => BeatSaberUI.MainTextFont != null);
                         Logger.log.Debug("Setting up default font fallbacks");
                         // FontManager doesn't give fixed fonts
-                        fallback = BeatSaberUI.CreateFixedUIFontClone(fallback);
+                        //fallback = BeatSaberUI.CreateFixedUIFontClone(fallback);
                         BeatSaberUI.MainTextFont.fallbackFontAssetTable.Add(fallback);
                     }
 

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -4,6 +4,7 @@ using BeatSaberMarkupLanguage.ViewControllers;
 using BS_Utils.Utilities;
 using HarmonyLib;
 using IPA;
+using IPA.Utilities.Async;
 using System;
 using System.Collections;
 using System.Linq;
@@ -36,6 +37,17 @@ namespace BeatSaberMarkupLanguage
             BSEvents.menuSceneLoadedFresh += MenuLoadFresh;
             config = new Config("BSML");
         }
+
+        [OnStart]
+        public void OnStart()
+        {
+            FontManager.AsyncLoadSystemFonts()
+                .ContinueWith(async _ =>
+                {
+                    // TODO: set up fallbacks for the default font
+                }, UnityMainThreadTaskScheduler.Default);
+        }
+
         public void MenuLoadFresh()
         {
             //GameplaySetup.GameplaySetup.instance.AddTab("Test", "BeatSaberMarkupLanguage.Views.gameplay-setup-test.bsml", GameplaySetupTest.instance);

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using System.Reflection;
+using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using IPALogger = IPA.Logging.Logger;
@@ -42,9 +43,20 @@ namespace BeatSaberMarkupLanguage
         public void OnStart()
         {
             FontManager.AsyncLoadSystemFonts()
-                .ContinueWith(async _ =>
+                .ContinueWith(_ =>
                 {
-                    // TODO: set up fallbacks for the default font
+                    if (!FontManager.TryGetTMPFontByFullName("Segoe UI", out TMP_FontAsset fallback))
+                    {
+                        if (!FontManager.TryGetTMPFontByFamily("Arial", out fallback))
+                        {
+                            Logger.log.Warn("Could not find fonts for either Segoe UI or Arial to set up fallbacks");
+                            return;
+                        }
+                    }
+
+                    // FontManager doesn't give fixed fonts
+                    fallback = BeatSaberUI.CreateFixedUIFontClone(fallback);
+                    BeatSaberUI.MainTextFont.fallbackFontAssetTable.Add(fallback);
                 }, UnityMainThreadTaskScheduler.Default);
         }
 

--- a/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
@@ -1,0 +1,47 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class ScrollIndicatorTag : BSMLTag
+    {
+        public override string[] Aliases { get; } = new[] { "vertical-scroll-indicator", "scroll-indicator" };
+
+        private static GameObject _verticalScrollTemplate = null;
+        public static GameObject VerticalScrollTemplate
+        {
+            get
+            {
+                if (_verticalScrollTemplate == null)
+                    _verticalScrollTemplate = Resources.FindObjectsOfTypeAll<VerticalScrollIndicator>().First().gameObject;
+
+                return _verticalScrollTemplate;
+            }
+        }
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameObject gameObject = Object.Instantiate(VerticalScrollTemplate);
+            gameObject.SetActive(false);
+            gameObject.name = "BSMLScrollIndicator";
+
+            RectTransform transform = gameObject.GetComponent<RectTransform>();
+            transform.SetParent(parent, false);
+
+            Object.Destroy(gameObject.GetComponent<VerticalScrollIndicator>());
+            BSMLScrollIndicator indicator = gameObject.AddComponent<BSMLScrollIndicator>();
+            indicator.Handle = transform.GetChild(0).GetComponent<RectTransform>();
+
+            gameObject.SetActive(true);
+            return gameObject;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollIndicatorTag.cs
@@ -36,7 +36,7 @@ namespace BeatSaberMarkupLanguage.Tags
             RectTransform transform = gameObject.GetComponent<RectTransform>();
             transform.SetParent(parent, false);
 
-            Object.Destroy(gameObject.GetComponent<VerticalScrollIndicator>());
+            Object.DestroyImmediate(gameObject.GetComponent<VerticalScrollIndicator>());
             BSMLScrollIndicator indicator = gameObject.AddComponent<BSMLScrollIndicator>();
             indicator.Handle = transform.GetChild(0).GetComponent<RectTransform>();
 

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -19,6 +19,12 @@ namespace BeatSaberMarkupLanguage.Tags
             go.SetActive(false);
 
             RectTransform transform = go.AddComponent<RectTransform>();
+            transform.SetParent(parent, false);
+            transform.localPosition = Vector2.zero;
+            transform.anchorMin = Vector2.zero;
+            transform.anchorMax = Vector2.one;
+            transform.anchoredPosition = Vector2.zero;
+            transform.sizeDelta = Vector2.zero;
 
             GameObject vpgo = new GameObject("Viewport");
             RectTransform viewport = vpgo.AddComponent<RectTransform>();
@@ -44,9 +50,10 @@ namespace BeatSaberMarkupLanguage.Tags
             content.anchorMax = new Vector2(1f, 1f);
             content.anchoredPosition = Vector2.zero;
 
-            var contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
-            var contentFitter = contentgo.AddComponent<ContentSizeFitter>();
-            contentFitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            VerticalLayoutGroup contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
+            ContentSizeFitter contentFitter = contentgo.AddComponent<ContentSizeFitter>();
+            LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
+            contentFitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
             contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
             contentLayout.childControlHeight = true;
             contentLayout.childControlWidth = false;
@@ -54,6 +61,7 @@ namespace BeatSaberMarkupLanguage.Tags
             contentLayout.childForceExpandWidth = true;
             contentLayout.childAlignment = TextAnchor.UpperCenter;
             contentLayout.spacing = 0f;
+            layoutElement.preferredWidth = -1;
 
             BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();
             scrollView.ContentRect = content;

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -50,17 +50,11 @@ namespace BeatSaberMarkupLanguage.Tags
             content.anchorMax = new Vector2(1f, 1f);
             content.anchoredPosition = Vector2.zero;
 
-            VerticalLayoutGroup contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
             ContentSizeFitter contentFitter = contentgo.AddComponent<ContentSizeFitter>();
             LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
             contentFitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
             contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-            contentLayout.childControlHeight = true;
-            contentLayout.childControlWidth = false;
-            contentLayout.childForceExpandHeight = false;
-            contentLayout.childForceExpandWidth = true;
-            contentLayout.childAlignment = TextAnchor.UpperCenter;
-            contentLayout.spacing = 0f;
+            layoutElement.minWidth = -1;
             layoutElement.preferredWidth = -1;
 
             BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -49,13 +49,20 @@ namespace BeatSaberMarkupLanguage.Tags
             content.anchorMin = new Vector2(0f, 1f);
             content.anchorMax = new Vector2(1f, 1f);
             content.anchoredPosition = Vector2.zero;
+            content.pivot = new Vector2(0.5f, 1f);
 
             ContentSizeFitter contentFitter = contentgo.AddComponent<ContentSizeFitter>();
-            LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
             contentFitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
             contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            VerticalLayoutGroup layout = contentgo.AddComponent<VerticalLayoutGroup>();
+            layout.childControlHeight = false;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = false;
+            /*LayoutElement layoutElement = contentgo.AddComponent<LayoutElement>();
             layoutElement.minWidth = -1;
             layoutElement.preferredWidth = -1;
+            layoutElement.flexibleWidth = 0;*/
+
 
             BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();
             scrollView.ContentRect = content;

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -1,0 +1,69 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class ScrollViewTag : BSMLTag
+    {
+        public override string[] Aliases { get; } = new[] { "scroll-view", "scroll" };
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameObject go = new GameObject("BSMLScrollView");
+            go.SetActive(false);
+
+            RectTransform transform = go.AddComponent<RectTransform>();
+
+            GameObject vpgo = new GameObject("Viewport");
+            RectTransform viewport = vpgo.AddComponent<RectTransform>();
+            viewport.SetParent(transform, false);
+            viewport.localPosition = Vector2.zero;
+            viewport.anchorMin = Vector2.zero;
+            viewport.anchorMax = Vector2.one;
+            viewport.anchoredPosition = Vector2.zero;
+            viewport.sizeDelta = Vector2.zero;
+
+            Mask vpmask = vpgo.AddComponent<Mask>();
+            Image vpimage = vpgo.AddComponent<Image>(); // a Mask needs an Image to work
+            vpmask.showMaskGraphic = false;
+            vpimage.color = Color.white;
+            vpimage.sprite = Utilities.ImageResources.WhitePixel;
+            vpimage.material = Utilities.ImageResources.NoGlowMat;
+
+            GameObject contentgo = new GameObject("Content Wrapper");
+            RectTransform content = contentgo.AddComponent<RectTransform>();
+            content.SetParent(viewport, false);
+            content.localPosition = Vector2.zero;
+            content.anchorMin = new Vector2(0f, 1f);
+            content.anchorMax = new Vector2(1f, 1f);
+            content.anchoredPosition = Vector2.zero;
+
+            var contentLayout = contentgo.AddComponent<VerticalLayoutGroup>();
+            var contentFitter = contentgo.AddComponent<ContentSizeFitter>();
+            contentFitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            contentFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            contentLayout.childControlHeight = true;
+            contentLayout.childControlWidth = false;
+            contentLayout.childForceExpandHeight = false;
+            contentLayout.childForceExpandWidth = true;
+            contentLayout.childAlignment = TextAnchor.UpperCenter;
+            contentLayout.spacing = 0f;
+
+            BSMLScrollViewElement scrollView = go.AddComponent<BSMLScrollViewElement>();
+            scrollView.ContentRect = content;
+            scrollView.Viewport = viewport;
+
+            BSMLScrollViewContent contentType = contentgo.AddComponent<BSMLScrollViewContent>();
+            contentType.ScrollView = scrollView;
+
+            go.SetActive(true);
+            return contentgo;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollIndicatorHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollIndicatorHandler.cs
@@ -1,0 +1,40 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(BSMLScrollIndicator))]
+    public class ScrollIndicatorHandler : TypeHandler<BSMLScrollIndicator>
+    {
+        public override Dictionary<string, string[]> Props { get; }
+            = new Dictionary<string, string[]>
+            {
+                { "handleColor", new[] { "handle-color" } },
+                { "handleImage", new[] { "handle-image" } },
+            };
+
+        public override Dictionary<string, Action<BSMLScrollIndicator, string>> Setters { get; }
+            = new Dictionary<string, Action<BSMLScrollIndicator, string>>
+            {
+                { "handleColor", TrySetHandleColor },
+                { "handleImage", (indic, src) => GetHandleImage(indic).SetImage(src) },
+            };
+
+        private static Image GetHandleImage(BSMLScrollIndicator indicator) => indicator.Handle.GetComponent<Image>();
+        private static void TrySetHandleColor(BSMLScrollIndicator indicator, string colorString)
+        {
+            if (!ColorUtility.TryParseHtmlString(colorString, out Color color))
+            {
+                Logger.log.Warn($"String {colorString} not a valid color");
+                return;
+            }
+            GetHandleImage(indicator).color = color;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -29,14 +29,6 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             {
                 parserParams.AddEvent(id + "#PageUp", scrollView.PageUpButtonPressed);
                 parserParams.AddEvent(id + "#PageDown", scrollView.PageDownButtonPressed);
-
-                scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
-                    .Select(o => o.GetComponent<Button>())
-                    .FirstOrDefault(b => b != null);
-
-                scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
-                    .Select(o => o.GetComponent<Button>())
-                    .FirstOrDefault(b => b != null);
             }
 
             if (componentType.data.TryGetValue("maskOverflow", out string value))
@@ -53,6 +45,26 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             foreach (GameObject go in parserParams.GetObjectsWithTag("ScrollFocus"))
             {
                 go.AddComponent<ItemForFocussedScrolling>();
+            }
+        }
+
+        public override void HandleTypeAfterParse(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
+            BSMLScrollViewElement scrollView = content.ScrollView;
+
+            Logger.log.Debug("Handling scroll view after parse");
+
+            if (componentType.data.TryGetValue("id", out string id))
+            {
+                Logger.log.Debug($"Looking for buttons tagged for {id}");
+                scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
+
+                scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
             }
 
             scrollView.Setup();

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -17,6 +17,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         public override Dictionary<string, string[]> Props { get; } = new Dictionary<string, string[]>
         {
             { "id", new[]{ "id" } },
+            { "maskOverflow", new[] { "mask-overflow" } }
         };
 
         public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -37,6 +38,11 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                     .Select(o => o.GetComponent<Button>())
                     .FirstOrDefault(b => b != null);
             }
+
+            if (componentType.data.TryGetValue("maskOverflow", out string value))
+            {
+                scrollView.MaskOverflow = bool.TryParse(value, out bool bval) ? bval : true;
+            }
         }
 
         public override void HandleTypeAfterChildren(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -51,6 +57,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
             scrollView.Setup();
             scrollView.RefreshButtonsInteractibility();
+            scrollView.ScrollAt(0, false);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -37,7 +37,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                 scrollView.MaskOverflow = bool.TryParse(value, out bool bval) ? bval : true;
             }
 
-            if (componentType.data.TryGetValue("align-bottom", out value))
+            if (componentType.data.TryGetValue("alignBottom", out value))
             {
                 scrollView.AlignBottom = bool.TryParse(value, out bool bval) ? bval : false;
             }

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -45,9 +45,6 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
         public override void HandleTypeAfterChildren(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
         {
-            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
-            BSMLScrollViewElement scrollView = content.ScrollView;
-
             foreach (GameObject go in parserParams.GetObjectsWithTag("ScrollFocus"))
             {
                 go.AddComponent<ItemForFocussedScrolling>();
@@ -59,11 +56,8 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
             BSMLScrollViewElement scrollView = content.ScrollView;
 
-            Logger.log.Debug("Handling scroll view after parse");
-
             if (componentType.data.TryGetValue("id", out string id))
             {
-                Logger.log.Debug($"Looking for buttons tagged for {id}");
                 scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
                     .Select(o => o.GetComponent<Button>())
                     .FirstOrDefault(b => b != null);
@@ -71,6 +65,10 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                 scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
                     .Select(o => o.GetComponent<Button>())
                     .FirstOrDefault(b => b != null);
+
+                scrollView.ScrollIndicator = parserParams.GetObjectsWithTag("IndicatorFor:" + id)
+                    .Select(o => o.GetComponent<VerticalScrollIndicator>() ?? o.GetComponent<BSMLScrollIndicator>())
+                    .FirstOrDefault(i => i != null);
             }
 
             scrollView.Setup();

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -17,7 +17,8 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         public override Dictionary<string, string[]> Props { get; } = new Dictionary<string, string[]>
         {
             { "id", new[]{ "id" } },
-            { "maskOverflow", new[] { "mask-overflow" } }
+            { "maskOverflow", new[] { "mask-overflow" } },
+            { "alignBottom", new[] { "align-bottom" } },
         };
 
         public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -34,6 +35,11 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             if (componentType.data.TryGetValue("maskOverflow", out string value))
             {
                 scrollView.MaskOverflow = bool.TryParse(value, out bool bval) ? bval : true;
+            }
+
+            if (componentType.data.TryGetValue("align-bottom", out value))
+            {
+                scrollView.AlignBottom = bool.TryParse(value, out bool bval) ? bval : false;
             }
         }
 
@@ -69,7 +75,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
             scrollView.Setup();
             scrollView.RefreshButtonsInteractibility();
-            scrollView.ScrollAt(0, false);
+            //scrollView.ScrollAt(0, false);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/ScrollViewHandler.cs
@@ -1,0 +1,56 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using BeatSaberMarkupLanguage.Parser;
+using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(BSMLScrollViewContent))]
+    public class ScrollViewHandler : TypeHandler
+    {
+        public override Dictionary<string, string[]> Props { get; } = new Dictionary<string, string[]>
+        {
+            { "id", new[]{ "id" } },
+        };
+
+        public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
+            BSMLScrollViewElement scrollView = content.ScrollView;
+
+            if (componentType.data.TryGetValue("id", out string id))
+            {
+                parserParams.AddEvent(id + "#PageUp", scrollView.PageUpButtonPressed);
+                parserParams.AddEvent(id + "#PageDown", scrollView.PageDownButtonPressed);
+
+                scrollView.PageUpButton = parserParams.GetObjectsWithTag("PageUpFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
+
+                scrollView.PageDownButton = parserParams.GetObjectsWithTag("PageDownFor:" + id)
+                    .Select(o => o.GetComponent<Button>())
+                    .FirstOrDefault(b => b != null);
+            }
+        }
+
+        public override void HandleTypeAfterChildren(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            BSMLScrollViewContent content = componentType.component as BSMLScrollViewContent;
+            BSMLScrollViewElement scrollView = content.ScrollView;
+
+            foreach (GameObject go in parserParams.GetObjectsWithTag("ScrollFocus"))
+            {
+                go.AddComponent<ItemForFocussedScrolling>();
+            }
+
+            scrollView.Setup();
+            scrollView.RefreshButtonsInteractibility();
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/TypeHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/TypeHandler.cs
@@ -22,6 +22,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         public abstract Dictionary<string, string[]> Props { get; }
         public abstract void HandleType(ComponentTypeWithData componentType, BSMLParserParams parserParams);
         public virtual void HandleTypeAfterChildren(ComponentTypeWithData componentType, BSMLParserParams parserParams) { }
+        public virtual void HandleTypeAfterParse(ComponentTypeWithData componentType, BSMLParserParams parserParams) { }
     }
 
     public abstract class TypeHandler<T> : TypeHandler

--- a/BeatSaberMarkupLanguage/Utilities.cs
+++ b/BeatSaberMarkupLanguage/Utilities.cs
@@ -97,6 +97,7 @@ namespace BeatSaberMarkupLanguage
         {
             private static Material noGlowMat;
             private static Sprite _blankSprite = null;
+            private static Sprite _whitePixel = null;
 
             public static Material NoGlowMat
             {
@@ -120,6 +121,17 @@ namespace BeatSaberMarkupLanguage
                         _blankSprite = Sprite.Create(Texture2D.blackTexture, new Rect(), Vector2.zero);
 
                     return _blankSprite;
+                }
+            }
+
+            public static Sprite WhitePixel
+            {
+                get
+                {
+                    if (!_whitePixel)
+                        _whitePixel = Resources.FindObjectsOfTypeAll<Image>().First(i => i.sprite?.name == "WhitePixel").sprite;
+
+                    return _whitePixel;
                 }
             }
         }

--- a/BeatSaberMarkupLanguage/Utilities.cs
+++ b/BeatSaberMarkupLanguage/Utilities.cs
@@ -215,6 +215,14 @@ namespace BeatSaberMarkupLanguage
             return data;
         }
 
+        public static IEnumerable<T> SingleEnumerable<T>(this T item) 
+            => Enumerable.Empty<T>().Append(item);
+
+        public static IEnumerable<T?> AsNullable<T>(this IEnumerable<T> seq) where T : struct
+            => seq.Select(v => new T?(v));
+
+        public static T? AsNullable<T>(this T item) where T : struct => item;
+
         /// <summary>
         /// Get data from either a resource path, a file path, or a url
         /// </summary>

--- a/BeatSaberMarkupLanguage/Views/test.bsml
+++ b/BeatSaberMarkupLanguage/Views/test.bsml
@@ -4,7 +4,16 @@
   <tab tags='new-tab' tab-name='~header'>
     <vertical>
       <horizontal pad-left='10' pad-right='10' horizontal-fit='PreferredSize'>
-        <text text='~header' color='red' align='Center' font-size='10'></text>
+        <vertical>
+          <text text='~header' color='red' align='Center' font-size='4'></text>
+          <text text='🎀 ここに変な手紙を入れましょう 🎀' />
+          <text text='בוא נקבל כמה אותיות מוזרות כאן' />
+          <text text='🎀 讓我們在這裡得到一些奇怪的信 🎀' />
+          <text text='la oss få noen rare brev her inne' />
+          <text text='여기에 이상한 글자를 줍시다' />
+          <text text='ας πάρουμε μερικά περίεργα γράμματα εδώ' />
+          <text text='давайте получим несколько странных писем здесь' />
+        </vertical>
       </horizontal>
       <horizontal bg='round-rect-panel' pad='6' spacing='10'>
         <button id='test-external' on-click='click' glow-color='green' text='~button-text'></button>
@@ -13,6 +22,7 @@
             <modal show-event='open-modal' hide-event='close-modal' size-delta-x='40' size-delta-y='30' move-to-center='false'>
               <vertical horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
                 <text text='Modal works yee haw'></text>
+                <text text='lèts gét sóme wierd letters ñ ╥ Ê' />
                 <button text='yee' click-event='close-modal'></button>
               </vertical>
             </modal>


### PR DESCRIPTION
This adds a `FontManager` type, responsible for managing and providing access to OpenType fonts. By default, it caches the information for all installed system fonts, and when accessing each font as a TMP font, automatically sets up fallbacks according to the system fallback chain configuration. This allows existing mods to use custom fonts without any extra work, and rich system integration for working with chaining.

This also automatically configures Beat Saber's default font to fall back to Segoe UI with its entire fallback chain. This allows song titles to contain almost any Unicode character in existence, even on a simple English Windows installation.

Basic usage is as follows:

```cs
if (!FontManager.TryGetTMPFontByFullName("Segoe UI", out var tmpFont))
{
    // report error and fail out, or try another font name
}

// tmpFont is now a correctly set up TMP_FontAsset with OS fallbacks
```

You can then use the TMP font for whatever text you have, and it will use the font given. You can also access fonts by their family and subfamily names:

```cs
if (!FontManager.TryGetTMPFontByFamily("Arial", out fallback))
{
    // report and fail out
}
```

Users can also register their own font files with `FontManager`, by calling `FontManager.AddFontFile(string)` with the path to the file. This will add its information to FontManager's cache, and make it accessible via all of the other FontManager APIs.

This PR builds on #31.