### PR TITLE
Added support for using Property and Method names directly in BSML files

### DIFF
--- a/BeatSaberMarkupLanguage/Attributes/HostOptionsAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/HostOptionsAttribute.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace BeatSaberMarkupLanguage.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed class HostOptionsAttribute : Attribute
+    {
+        public PropertyAccessOption PropertyAccessOption { get; }
+        public MethodAccessOption MethodAccessOption { get; }
+        public HostOptionsAttribute(PropertyAccessOption propertyAccessOption = PropertyAccessOption.Auto,
+            MethodAccessOption methodAccessOption = MethodAccessOption.Auto)
+        {
+            PropertyAccessOption = propertyAccessOption;
+            MethodAccessOption = methodAccessOption;
+        }
+    }
+
+    public enum MethodAccessOption
+    {
+        /// <summary>
+        /// Methods not marked with <see cref="UIAction"/> can be used in BSML files using their method name.
+        /// If a <see cref="UIAction"/> has the same name as an unmarked method, the <see cref="UIAction"/> will be used.
+        /// </summary>
+        Auto = 0,
+        /// <summary>
+        /// Only methods marked with <see cref="UIAction"/> can by used in BSML files.
+        /// </summary>
+        OptIn = 1,
+        /// <summary>
+        /// Methods marked with <see cref="UIAction"/> can be accessed by both the <see cref="UIAction.id"/> and their method name.
+        /// </summary>
+        AllowBoth = 2
+    }
+
+    public enum PropertyAccessOption
+    {
+        /// <summary>
+        /// Properties not marked with <see cref="UIValue"/> can be used in BSML files using their property name.
+        /// If a <see cref="UIValue"/> has the same name as an unmarked property, the <see cref="UIValue"/> will be used.
+        /// </summary>
+        Auto = 0,
+        /// <summary>
+        /// Only properties marked with <see cref="UIValue"/> can by used in BSML files.
+        /// </summary>
+        OptIn = 1,
+        /// <summary>
+        /// Properties marked with <see cref="UIValue"/> can be accessed by both the <see cref="UIValue.id"/> and their property name.
+        /// </summary>
+        AllowBoth = 2
+    }
+}

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Animations\GIF\GIFUnityDecoder.cs" />
     <Compile Include="Animations\AnimationInfo.cs" />
     <Compile Include="Animations\LockBitmap.cs" />
+    <Compile Include="Attributes\HostOptionsAttribute.cs" />
     <Compile Include="Attributes\HotReloadAttribute.cs" />
     <Compile Include="Attributes\UIAction.cs" />
     <Compile Include="Attributes\UIComponent.cs" />

--- a/BeatSaberMarkupLanguage/Macros/DefineMacro.cs
+++ b/BeatSaberMarkupLanguage/Macros/DefineMacro.cs
@@ -27,7 +27,7 @@ namespace BeatSaberMarkupLanguage.Macros
             if (parserParams.values.TryGetValue(name, out BSMLValue existingValue))
                 existingValue.SetValue(value);
             else
-                parserParams.values.Add(name, new BSMLStringValue(value));
+                parserParams.values.Add(name, new BSMLStringValue(value, name));
         }
     }
 }

--- a/BeatSaberMarkupLanguage/Parser/BSMLAction.cs
+++ b/BeatSaberMarkupLanguage/Parser/BSMLAction.cs
@@ -4,13 +4,15 @@ namespace BeatSaberMarkupLanguage.Parser
 {
     public class BSMLAction
     {
-        private object host;
-        private MethodInfo methodInfo;
-
-        public BSMLAction(object host, MethodInfo methodInfo)
+        protected object host;
+        internal MethodInfo methodInfo;
+        public bool FromUIAction { get; internal set; }
+        public string MemberName => methodInfo?.Name;
+        public BSMLAction(object host, MethodInfo methodInfo, bool fromUiAction = true)
         {
             this.host = host;
             this.methodInfo = methodInfo;
+            FromUIAction = fromUiAction;
         }
 
         public object Invoke(params object[] parameters)

--- a/BeatSaberMarkupLanguage/Parser/BSMLFieldValue.cs
+++ b/BeatSaberMarkupLanguage/Parser/BSMLFieldValue.cs
@@ -4,13 +4,14 @@ namespace BeatSaberMarkupLanguage.Parser
 {
     public class BSMLFieldValue : BSMLValue
     {
-        private object host;
-        private FieldInfo fieldInfo;
+        internal FieldInfo fieldInfo;
+        public override string MemberName => fieldInfo?.Name;
 
-        public BSMLFieldValue(object host, FieldInfo fieldInfo)
+        public BSMLFieldValue(object host, FieldInfo fieldInfo, bool fromUiValue = true)
         {
             this.host = host;
             this.fieldInfo = fieldInfo;
+            FromUIValue = fromUiValue;
         }
 
         public override object GetValue()

--- a/BeatSaberMarkupLanguage/Parser/BSMLPropertyValue.cs
+++ b/BeatSaberMarkupLanguage/Parser/BSMLPropertyValue.cs
@@ -5,13 +5,14 @@ namespace BeatSaberMarkupLanguage.Parser
 {
     public class BSMLPropertyValue : BSMLValue
     {
-        private object host;
         internal PropertyInfo propertyInfo;
+        public override string MemberName => propertyInfo?.Name;
 
-        public BSMLPropertyValue(object host, PropertyInfo propertyInfo)
+        public BSMLPropertyValue(object host, PropertyInfo propertyInfo, bool fromUiValue = true)
         {
             this.host = host;
             this.propertyInfo = propertyInfo;
+            FromUIValue = fromUiValue;
         }
 
         public override object GetValue()

--- a/BeatSaberMarkupLanguage/Parser/BSMLStringValue.cs
+++ b/BeatSaberMarkupLanguage/Parser/BSMLStringValue.cs
@@ -3,10 +3,12 @@
     public class BSMLStringValue : BSMLValue
     {
         private string value;
+        public override string MemberName { get; }
 
-        public BSMLStringValue(string value)
+        public BSMLStringValue(string value, string memberName = "")
         {
             this.value = value;
+            MemberName = memberName;
         }
 
         public override object GetValue()

--- a/BeatSaberMarkupLanguage/Parser/BSMLValue.cs
+++ b/BeatSaberMarkupLanguage/Parser/BSMLValue.cs
@@ -2,6 +2,9 @@
 {
     public abstract class BSMLValue
     {
+        protected object host;
+        public abstract string MemberName { get; }
+        public bool FromUIValue { get; internal set; }
         public abstract void SetValue(object value);
         public abstract object GetValue();
     }


### PR DESCRIPTION
This PR allows you to use property and method names from the host object directly in BSML files. This is useful for when the host object is defined in an assembly that doesn't reference BSML. Members with the UIValue/UIAction will take priority over any unmarked members.

I've also added `HostOptionsAttribute` class attribute to change this behavior. There are separate options for properties and methods:
* Auto (default): Members not marked with an attribute can be used in BSML files by their name. Marked members can only be identified by the attribute ID.
* OptIn: Only members marked with an attribute can be accessed by BSML files.
* AllowBoth: Members can be accessed by both the attribute ID and the member name (as long as there's no conflicts with other attribute IDs)