### PR TITLE
Added FormattableText Component

### DIFF
--- a/BeatSaberMarkupLanguage/BSMLParser.cs
+++ b/BeatSaberMarkupLanguage/BSMLParser.cs
@@ -39,6 +39,15 @@ namespace BeatSaberMarkupLanguage
                 RegisterMacro(macro);
 
             typeHandlers = Utilities.GetListOfType<TypeHandler>();
+            foreach (TypeHandler typeHandler in typeHandlers.ToArray())
+            {
+                Type type = (typeHandler.GetType().GetCustomAttributes(typeof(ComponentHandler), true).FirstOrDefault() as ComponentHandler)?.type;
+                if (type == null)
+                {
+                    Logger.log.Warn($"TypeHandler {typeHandler.GetType().FullName} does not have the [ComponentHandler] attribute and will be ignored.");
+                    typeHandlers.Remove(typeHandler);
+                }
+            }
         }
 
         public void MenuSceneLoaded()
@@ -166,7 +175,9 @@ namespace BeatSaberMarkupLanguage
             List<ComponentTypeWithData> componentTypes = new List<ComponentTypeWithData>();
             foreach (TypeHandler typeHandler in typeHandlers)
             {
-                Type type = (typeHandler.GetType().GetCustomAttributes(typeof(ComponentHandler), true).FirstOrDefault() as ComponentHandler).type;
+                Type type = (typeHandler.GetType().GetCustomAttributes(typeof(ComponentHandler), true).FirstOrDefault() as ComponentHandler)?.type;
+                if (type == null)
+                    continue;
                 Component component = GetExternalComponent(currentNode, type);
                 if (component != null)
                 {
@@ -262,11 +273,19 @@ namespace BeatSaberMarkupLanguage
                         string value = node.Attributes[alias].Value;
                         if (value.StartsWith(RETRIEVE_VALUE_PREFIX))
                         {
-                            string valueID = value.Substring(1);
-                            if (!parserParams.values.TryGetValue(valueID, out BSMLValue uiValue) && uiValue != null)
-                                throw new Exception("No UIValue exists with the id '" + valueID + "'");
-                            parameters.Add(propertyAliases.Key, uiValue.GetValue()?.InvariantToString());
-                            valueMap.Add(propertyAliases.Key, uiValue);
+                            try
+                            {
+                                string valueID = value.Substring(1);
+                                if (!parserParams.values.TryGetValue(valueID, out BSMLValue uiValue) || uiValue == null)
+                                    throw new Exception("No UIValue exists with the id '" + valueID + "'");
+                                parameters.Add(propertyAliases.Key, uiValue.GetValue()?.InvariantToString());
+                                valueMap.Add(propertyAliases.Key, uiValue);
+                            }
+                            catch (Exception)
+                            {
+                                Logger.log?.Error($"Error parsing '{propertyAliases.Key}'='{value}' in {parserParams.host?.GetType().FullName}");
+                                throw;
+                            }
                         }
                         else
                         {

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Components\ClickableText.cs" />
     <Compile Include="Components\CustomCellListTableData.cs" />
     <Compile Include="Components\ExternalComponents.cs" />
+    <Compile Include="Components\FormattableText.cs" />
     <Compile Include="Components\Glowable.cs" />
     <Compile Include="Components\ModalColorPicker.cs" />
     <Compile Include="Components\ModalKeyboard.cs" />
@@ -269,6 +270,7 @@
     <Compile Include="TypeHandlers\ContentSizeFitterHandler.cs" />
     <Compile Include="TypeHandlers\CustomCellListTableDataHandler.cs" />
     <Compile Include="TypeHandlers\CustomListTableDataHandler.cs" />
+    <Compile Include="TypeHandlers\FormattableTextHandler.cs" />
     <Compile Include="TypeHandlers\GlowableHandler.cs" />
     <Compile Include="TypeHandlers\GridLayoutGroupHandler.cs" />
     <Compile Include="TypeHandlers\HorizontalOrVerticalLayoutGroupHandler.cs" />

--- a/BeatSaberMarkupLanguage/Components/FormattableText.cs
+++ b/BeatSaberMarkupLanguage/Components/FormattableText.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TMPro;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class FormattableText : TextMeshProUGUI
+    {
+        private string textFormat;
+        private ICustomFormatter textFormatter;
+        private object data;
+        public object Data
+        {
+            get => data;
+            set
+            {
+                data = value;
+                RefreshText();
+            }
+        }
+
+        public void RefreshText()
+        {
+            if (data == null)
+                return;
+            string val;
+            
+            object o = data;
+            if (TextFormatter != null)
+                val = TextFormatter.Format(TextFormat, o, null);
+            else if (o is IFormattable formattable && !string.IsNullOrEmpty(TextFormat))
+                val = formattable.ToString(TextFormat, null); // TODO: Will this cause problems for certain types if formatProvider is null?
+            else
+            {
+                val = o?.ToString() ?? "";
+            }
+            text = val;
+        }
+
+        public ICustomFormatter TextFormatter
+        {
+            get => textFormatter;
+            set
+            {
+                if (textFormatter == value)
+                    return;
+                textFormatter = value;
+                RefreshText();
+            }
+        }
+
+        public string TextFormat
+        {
+            get => textFormat;
+            set
+            {
+                if (textFormat == value)
+                    return;
+                textFormat = value;
+                RefreshText();
+            }
+        }
+
+        public void SetFormatter(object formatter)
+        {
+            if (formatter == null)
+            {
+                TextFormatter = null;
+                return;
+            }
+            if (formatter is ICustomFormatter valueConverter)
+            {
+                TextFormatter = valueConverter;
+            }
+            else
+            {
+                throw new ArgumentException("formatter must by of type 'ICustomFormatter'", nameof(formatter));
+            }
+        }
+
+        protected override void OnDestroy()
+        {
+            EventHandler handler = Destroyed;
+            if (handler != null)
+                handler.Invoke(this, null);
+            base.OnDestroy();
+        }
+
+        public event EventHandler Destroyed;
+    }
+}

--- a/BeatSaberMarkupLanguage/Tags/TextTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/TextTag.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using BeatSaberMarkupLanguage.Components;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 
@@ -13,7 +14,7 @@ namespace BeatSaberMarkupLanguage.Tags
             GameObject gameObj = new GameObject("BSMLText");
             gameObj.transform.SetParent(parent, false);
 
-            TextMeshProUGUI textMesh = gameObj.AddComponent<TextMeshProUGUI>();
+            FormattableText textMesh = gameObj.AddComponent<FormattableText>();
             textMesh.font = MonoBehaviour.Instantiate(Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(t => t.name == "Teko-Medium SDF No Glow"));
             textMesh.fontSize = 4;
             textMesh.color = Color.white;

--- a/BeatSaberMarkupLanguage/TypeHandlers/FormattableTextHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/FormattableTextHandler.cs
@@ -59,11 +59,12 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                 }
                 else if (dataStr != null)
                 {
-                    Logger.log?.Warn($"'{dataStr}' does not exist in host {parserParams.host?.GetType().Name}");
+                    formattableText.Data = dataStr;
                 }
 
                 //-----data-formatter-----
-                if (formatterValue != null)
+                if (formatterValue != null || (componentType.data.TryGetValue("data-formatter", out string formatterStr)
+                    && parserParams.values.TryGetValue(formatterStr, out formatterValue)))
                 {
                     formattableText.SetFormatter(formatterValue.GetValue());
                     if (formatterValue is BSMLPropertyValue formatterProp)

--- a/BeatSaberMarkupLanguage/TypeHandlers/FormattableTextHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/FormattableTextHandler.cs
@@ -63,8 +63,9 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                 }
 
                 //-----data-formatter-----
-                if (formatterValue != null || (componentType.data.TryGetValue("data-formatter", out string formatterStr)
-                    && parserParams.values.TryGetValue(formatterStr, out formatterValue)))
+                if (formatterValue != null 
+                    || (componentType.data.TryGetValue("data-formatter", out string formatterStr)
+                        && (parserParams?.values?.TryGetValue(formatterStr, out formatterValue) ?? false)))
                 {
                     formattableText.SetFormatter(formatterValue.GetValue());
                     if (formatterValue is BSMLPropertyValue formatterProp)

--- a/BeatSaberMarkupLanguage/TypeHandlers/FormattableTextHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/FormattableTextHandler.cs
@@ -1,0 +1,95 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using BeatSaberMarkupLanguage.Notify;
+using BeatSaberMarkupLanguage.Parser;
+using IPA.Config.Stores;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TMPro;
+using UnityEngine;
+using UnityEngine.PlayerLoop;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(FormattableText))]
+    public class FormattableTextHandler : TypeHandler<FormattableText>
+    {
+
+        public override Dictionary<string, string[]> Props => new Dictionary<string, string[]>()
+        {
+            { "data", new[]{ "data" } },
+            { "data-format", new[]{ "data-format" } },
+            { "data-formatter", new[]{ "data-formatter" } }
+        };
+
+        public override Dictionary<string, Action<FormattableText, string>> Setters { get; } = new Dictionary<string, Action<FormattableText, string>>()
+        {
+            {"data-format", new Action<FormattableText,string>((formattableText, value) => formattableText.TextFormat = value) },
+        };
+
+        public override void HandleType(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            base.HandleType(componentType, parserParams);
+            if (componentType.component is FormattableText formattableText)
+            {
+                NotifyUpdater updater = null;
+                BSMLValue dataValue = null;
+                BSMLValue formatterValue = null;
+
+                if (componentType.propertyMap != null)
+                {
+                    dataValue = componentType.propertyMap.TryGetValue("data", out BSMLPropertyValue existingProp) 
+                        ? existingProp : null;
+                    formatterValue = componentType.propertyMap.TryGetValue("data-formatter", out existingProp) 
+                        ? existingProp : null;
+                }
+
+                //-----data-----
+                if (dataValue != null || (componentType.data.TryGetValue("data", out string dataStr)
+                    && parserParams.values.TryGetValue(dataStr, out dataValue)))
+                {
+                    formattableText.Data = dataValue.GetValue();
+                    if (dataValue is BSMLPropertyValue dataProp)
+                    {
+                        if (updater == null)
+                            updater = CreateNotifyUpdater(componentType, parserParams);
+                        updater.AddAction(dataProp.propertyInfo.Name, val => formattableText.Data = val);
+                    }
+                }
+                else if (dataStr != null)
+                {
+                    Logger.log?.Warn($"'{dataStr}' does not exist in host {parserParams.host?.GetType().Name}");
+                }
+
+                //-----data-formatter-----
+                if (formatterValue != null)
+                {
+                    formattableText.SetFormatter(formatterValue.GetValue());
+                    if (formatterValue is BSMLPropertyValue formatterProp)
+                    {
+                        if (updater == null)
+                            updater = CreateNotifyUpdater(componentType, parserParams);
+                        updater.AddAction(formatterProp.propertyInfo.Name, val => formattableText.SetFormatter(val));
+                    }
+                }
+            }
+
+        }
+
+        internal static NotifyUpdater CreateNotifyUpdater(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
+        {
+            NotifyUpdater updater = null;
+            if (parserParams.host is INotifiableHost notifyHost && componentType.propertyMap != null)
+            {
+                updater = componentType.component.gameObject.GetComponent<NotifyUpdater>();
+                if (updater == null)
+                {
+                    updater = componentType.component.gameObject.AddComponent<NotifyUpdater>();
+                    updater.NotifyHost = notifyHost;
+                }
+            }
+            return updater;
+        }
+    }
+}


### PR DESCRIPTION
The `text` tag now creates a new `FormattableText` component (derived from TextMeshProUGUI).

Adds the following parameters to the `text` tag:
* 'data': Object to be displayed as text after formatting (if any).
* 'data-format': The string defining the format (can be null/empty).
* 'data-formatter': Points to a UIValue containing an ICustomFormatter object.

The `data-formatter` can be left blank if the data object implements IFormattable (such as int/float/etc).
In BSML, `data` can either be prefixed with `~` or not. I'm not sure if that's desirable.
Haven't fully tested to make sure it doesn't break anything yet.