### PR TITLE
Event for handle grab/release exposed by FloatingScreen

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -25,13 +25,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BS_Utils">

--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
@@ -110,14 +110,11 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
 
         private void CreateHandle()
         {
-            VRPointer[] vrPointers = Resources.FindObjectsOfTypeAll<VRPointer>();
-            if (vrPointers.Count() != 0)
+            VRPointer pointer = Resources.FindObjectsOfTypeAll<VRPointer>().FirstOrDefault();
+            if (pointer != null)
             {
-                VRPointer pointer = vrPointers.First();
                 if (screenMover) Destroy(screenMover);
                 screenMover = pointer.gameObject.AddComponent<FloatingScreenMoverPointer>();
-                screenMover.OnGrab = OnHandleGrab;
-                screenMover.OnRelease = OnHandleReleased;
                 handle = GameObject.CreatePrimitive(PrimitiveType.Cube);
 
                 handle.transform.SetParent(transform);
@@ -131,13 +128,13 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
             }
         }
 
-        protected void OnHandleGrab(Vector3 position, Quaternion rotation)
+        internal void OnHandleGrab(VRPointer vrPointer)
         {
-            HandleGrabbed?.Invoke(this, new FloatingScreenHandleEventArgs(position, rotation));
+            HandleGrabbed?.Invoke(this, new FloatingScreenHandleEventArgs(vrPointer, transform.position, transform.rotation));
         }
-        protected void OnHandleReleased(Vector3 position, Quaternion rotation)
+        internal void OnHandleReleased(VRPointer vrPointer)
         {
-            HandleReleased?.Invoke(this, new FloatingScreenHandleEventArgs(position, rotation));
+            HandleReleased?.Invoke(this, new FloatingScreenHandleEventArgs(vrPointer, transform.position, transform.rotation));
         }
 
         public void UpdateHandle()
@@ -171,12 +168,14 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
     }
     public struct FloatingScreenHandleEventArgs
     {
-        public FloatingScreenHandleEventArgs(Vector3 position, Quaternion rotation)
+        public FloatingScreenHandleEventArgs(VRPointer vrPointer, Vector3 position, Quaternion rotation)
         {
+            Pointer = vrPointer;
             Position = position;
             Rotation = rotation;
         }
 
+        public readonly VRPointer Pointer;
         public readonly Vector3 Position;
         public readonly Quaternion Rotation;
 

--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
@@ -20,8 +20,8 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
         protected Quaternion _realRot;
         protected bool _isFpfc;
 
-        public Action<Vector3, Quaternion> OnGrab;
-        public Action<Vector3, Quaternion> OnRelease;
+        internal Action<Vector3, Quaternion> OnGrab;
+        internal Action<Vector3, Quaternion> OnRelease;
 
         public virtual void Init(FloatingScreen floatingScreen)
         {
@@ -53,6 +53,16 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
                 _isFpfc && Input.GetMouseButton(0)) return;
             _grabbingController = null;
             OnRelease?.Invoke(_floatingScreen.transform.position, _floatingScreen.transform.rotation);
+        }
+
+        protected void OnDestroy()
+        {
+            OnGrab = null;
+            OnRelease = null;
+            _vrPointer = null;
+            _floatingScreen = null;
+            _screenHandle = null;
+            _grabbingController = null;
         }
 
         protected virtual void LateUpdate()

--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
@@ -20,31 +20,41 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
         protected Quaternion _realRot;
         protected bool _isFpfc;
 
-        internal Action<Vector3, Quaternion> OnGrab;
-        internal Action<Vector3, Quaternion> OnRelease;
+        [Obsolete("Use FloatingScreen.HandleGrabbed event")]
+        public Action<Vector3, Quaternion> OnGrab;
+        [Obsolete("Use FloatingScreen.HandleReleased event")]
+        public Action<Vector3, Quaternion> OnRelease;
 
-        public virtual void Init(FloatingScreen floatingScreen)
+        public virtual void Init(FloatingScreen floatingScreen, VRPointer pointer)
         {
             _floatingScreen = floatingScreen;
             _screenHandle = floatingScreen.handle.transform;
             _realPos = floatingScreen.transform.position;
             _realRot = floatingScreen.transform.rotation;
-            _vrPointer = GetComponent<VRPointer>();
+            _vrPointer = pointer;
             _isFpfc = Environment.CommandLine.Contains("fpfc");
+        }
+
+        public virtual void Init(FloatingScreen floatingScreen)
+        {
+            VRPointer vrPointer = GetComponent<VRPointer>();
+            Init(floatingScreen, vrPointer);
         }
 
         protected virtual void Update()
         {
-            if (_vrPointer.vrController != null)
-                if (_vrPointer.vrController.triggerValue > 0.9f || Input.GetMouseButton(0))
+            VRPointer pointer = _vrPointer;
+            if (pointer?.vrController != null)
+                if (pointer.vrController.triggerValue > 0.9f || Input.GetMouseButton(0))
                 {
                     if (_grabbingController != null) return;
-                    if (Physics.Raycast(_vrPointer.vrController.position, _vrPointer.vrController.forward, out RaycastHit hit, MaxLaserDistance))
+                    if (Physics.Raycast(pointer.vrController.position, pointer.vrController.forward, out RaycastHit hit, MaxLaserDistance))
                     {
                         if (hit.transform != _screenHandle) return;
-                        _grabbingController = _vrPointer.vrController;
-                        _grabPos = _vrPointer.vrController.transform.InverseTransformPoint(_floatingScreen.transform.position);
-                        _grabRot = Quaternion.Inverse(_vrPointer.vrController.transform.rotation) * _floatingScreen.transform.rotation;
+                        _grabbingController = pointer.vrController;
+                        _grabPos = pointer.vrController.transform.InverseTransformPoint(_floatingScreen.transform.position);
+                        _grabRot = Quaternion.Inverse(pointer.vrController.transform.rotation) * _floatingScreen.transform.rotation;
+                        _floatingScreen.OnHandleGrab(pointer);
                         OnGrab?.Invoke(_floatingScreen.transform.position, _floatingScreen.transform.rotation);
                     }
                 }
@@ -52,6 +62,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
             if (_grabbingController == null || !_isFpfc && _grabbingController.triggerValue > 0.9f ||
                 _isFpfc && Input.GetMouseButton(0)) return;
             _grabbingController = null;
+            _floatingScreen.OnHandleReleased(pointer);
             OnRelease?.Invoke(_floatingScreen.transform.position, _floatingScreen.transform.rotation);
         }
 


### PR DESCRIPTION
Event for HandleGrabbed/Released exposed by `FloatingScreen` instead of actions in `FloatingScreenMoverPointer`.
* More reliable if the handle is shown after `FloatingScreen` is created. Consumers won't have to worry about assigning the actions when the handle is shown for the first time, just when the FloatingScreen is created.