### PR TITLE
Relative path to layout file in HotReload attribute

### DIFF
--- a/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
+++ b/BeatSaberMarkupLanguage/Attributes/HotReloadAttribute.cs
@@ -19,6 +19,11 @@ namespace BeatSaberMarkupLanguage.Attributes
         /// and the second of each pair is the target.
         /// </summary>
         public string[] PathMap { get; set; }
+        
+        /// <summary>
+        /// Can be used to specify the path to the layout file relative to the path of class in which the attribute is being used.
+        /// </summary>
+        public string RelativePathToLayout { get; set; }
 
         private string _path = null;
         public string Path
@@ -39,7 +44,10 @@ namespace BeatSaberMarkupLanguage.Attributes
                             }
                         }
                     }
-                    if (_path == null) _path = GivenPath;
+
+                    _path ??= RelativePathToLayout != null
+                        ? System.IO.Path.GetFullPath(System.IO.Path.GetDirectoryName(GivenPath) + System.IO.Path.DirectorySeparatorChar + RelativePathToLayout)
+                        : GivenPath;
                 }
                 return _path;
             }


### PR DESCRIPTION
This PR adds the ability to specify a relative path to a layout file in the HotReload attribute. The path to the layout file is relative to the path of the directory path of the class in which the attribute is being used. It also gives developers the ability to use layout files with names that differ from the names of their respective viewcontrollers.

Given the following file structure (it also works with others btw)
```
UI
 |  ViewController.cs
 |  Views
 |    | -- View.bsml 
```

You can specify the relative path for HotReloading in the ViewController like this.
```csharp
[HotReload(RelativePathToLayout = @"Views\View.bsml")]
```