### PR TITLE
Fixed possible false positive detection of fpfc

### DIFF
--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using UnityEngine;
 using VRUIControls;
 
@@ -32,7 +33,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
             _realPos = floatingScreen.transform.position;
             _realRot = floatingScreen.transform.rotation;
             _vrPointer = pointer;
-            _isFpfc = Environment.CommandLine.Contains("fpfc");
+            _isFpfc = Environment.CommandLine.Split(' ').Contains("fpfc");
         }
 
         public virtual void Init(FloatingScreen floatingScreen)

--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreenMoverPointer.cs
@@ -19,7 +19,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
         protected Quaternion _grabRot;
         protected Vector3 _realPos;
         protected Quaternion _realRot;
-        protected bool _isFpfc;
+        protected FirstPersonFlyingController _fpfc;
 
         [Obsolete("Use FloatingScreen.HandleGrabbed event")]
         public Action<Vector3, Quaternion> OnGrab;
@@ -33,7 +33,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
             _realPos = floatingScreen.transform.position;
             _realRot = floatingScreen.transform.rotation;
             _vrPointer = pointer;
-            _isFpfc = Environment.CommandLine.Split(' ').Contains("fpfc");
+            _fpfc = Resources.FindObjectsOfTypeAll<FirstPersonFlyingController>().FirstOrDefault();    
         }
 
         public virtual void Init(FloatingScreen floatingScreen)
@@ -41,6 +41,8 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
             VRPointer vrPointer = GetComponent<VRPointer>();
             Init(floatingScreen, vrPointer);
         }
+
+        private bool IsFpfc => _fpfc != null &&_fpfc.enabled;
 
         protected virtual void Update()
         {
@@ -60,8 +62,8 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
                     }
                 }
 
-            if (_grabbingController == null || !_isFpfc && _grabbingController.triggerValue > 0.9f ||
-                _isFpfc && Input.GetMouseButton(0)) return;
+            if (_grabbingController == null || !IsFpfc && _grabbingController.triggerValue > 0.9f ||
+                IsFpfc && Input.GetMouseButton(0)) return;
             _grabbingController = null;
             _floatingScreen.OnHandleReleased(pointer);
             OnRelease?.Invoke(_floatingScreen.transform.position, _floatingScreen.transform.rotation);


### PR DESCRIPTION
This PR fixes some possible false positive detections of `fpfc`.
If someone tried to disable `fpfc` by adding a character in the beginning or at the end of the argument, BSML would still detect it as fpfc despite that Beat Saber doesn't accept it as a valid argument.