### PR TITLE
Deprecated INotifiableHost for INotifyPropertyChanged

### DIFF
--- a/BeatSaberMarkupLanguage/BSMLParser.cs
+++ b/BeatSaberMarkupLanguage/BSMLParser.cs
@@ -1,7 +1,6 @@
 ﻿using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Macros;
-using BeatSaberMarkupLanguage.Notify;
 using BeatSaberMarkupLanguage.Parser;
 using BeatSaberMarkupLanguage.Tags;
 using BeatSaberMarkupLanguage.TypeHandlers;
@@ -342,7 +341,7 @@ namespace BeatSaberMarkupLanguage
         private Dictionary<string, string> GetParameters(XmlNode node, Dictionary<string, string[]> properties, BSMLParserParams parserParams, out Dictionary<string, BSMLValue> valueMap)
         {
             Dictionary<string, string> parameters = new Dictionary<string, string>();
-            bool isNotifyHost = parserParams.host == null ? false : typeof(INotifiableHost).IsAssignableFrom(parserParams.host.GetType());
+            bool isNotifyHost = parserParams.host == null ? false : typeof(System.ComponentModel.INotifyPropertyChanged).IsAssignableFrom(parserParams.host.GetType());
             valueMap = new Dictionary<string, BSMLValue>();
             foreach (KeyValuePair<string, string[]> propertyAliases in properties)
             {

--- a/BeatSaberMarkupLanguage/Components/NotifiableSingleton.cs
+++ b/BeatSaberMarkupLanguage/Components/NotifiableSingleton.cs
@@ -1,11 +1,11 @@
-﻿using BeatSaberMarkupLanguage.Notify;
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace BeatSaberMarkupLanguage.Components
 {
-    public class NotifiableSingleton<T> : PersistentSingleton<T>, INotifiableHost where T : MonoBehaviour
+    public class NotifiableSingleton<T> : PersistentSingleton<T>, INotifyPropertyChanged where T : MonoBehaviour
     {
         public event PropertyChangedEventHandler PropertyChanged;
         protected void NotifyPropertyChanged([CallerMemberName] string propertyName = "")

--- a/BeatSaberMarkupLanguage/Components/NotifyUpdater.cs
+++ b/BeatSaberMarkupLanguage/Components/NotifyUpdater.cs
@@ -1,6 +1,6 @@
-﻿using BeatSaberMarkupLanguage.Notify;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using UnityEngine;
 
@@ -8,8 +8,8 @@ namespace BeatSaberMarkupLanguage.Components
 {
     public class NotifyUpdater : MonoBehaviour
     {
-        private INotifiableHost _notifyHost;
-        public INotifiableHost NotifyHost
+        private INotifyPropertyChanged _notifyHost;
+        public INotifyPropertyChanged NotifyHost
         {
             get { return _notifyHost; }
             set

--- a/BeatSaberMarkupLanguage/MenuButtons/MenuButton.cs
+++ b/BeatSaberMarkupLanguage/MenuButtons/MenuButton.cs
@@ -1,11 +1,11 @@
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using BeatSaberMarkupLanguage.Attributes;
-using BeatSaberMarkupLanguage.Notify;
 
 namespace BeatSaberMarkupLanguage.MenuButtons
 {
-    public class MenuButton : INotifiableHost
+    public class MenuButton : INotifyPropertyChanged
     {
         public virtual Action OnClick { get; protected set; }
         

--- a/BeatSaberMarkupLanguage/MenuButtons/MenuButtons.cs
+++ b/BeatSaberMarkupLanguage/MenuButtons/MenuButtons.cs
@@ -1,11 +1,11 @@
 ﻿using BeatSaberMarkupLanguage.Attributes;
-using BeatSaberMarkupLanguage.Notify;
 using BeatSaberMarkupLanguage.Parser;
 using HMUI;
 using IPA.Utilities;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -149,7 +149,7 @@ namespace BeatSaberMarkupLanguage.MenuButtons
             Plugin.config.SetString("Pins", "Pinned Mods", string.Join(",", Pins));
         }
     }
-    internal class PinnedMod : INotifiableHost
+    internal class PinnedMod : INotifyPropertyChanged
     {
         [UIValue("menu-button")]
         public MenuButton menuButton;

--- a/BeatSaberMarkupLanguage/Notify/INotifiableHost.cs
+++ b/BeatSaberMarkupLanguage/Notify/INotifiableHost.cs
@@ -1,24 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BeatSaberMarkupLanguage.Notify
 {
-    public interface INotifiableHost
+    [Obsolete("Use System.ComponentModel.INotifyPropertyChanged.")]
+    public interface INotifiableHost : System.ComponentModel.INotifyPropertyChanged
     {
-        event PropertyChangedEventHandler PropertyChanged;
+
     }
 
-    public delegate void PropertyChangedEventHandler(object sender, PropertyChangedEventArgs e);
+    // public delegate void PropertyChangedEventHandler(object sender, PropertyChangedEventArgs e);
 
-    public class PropertyChangedEventArgs : EventArgs
+    [Obsolete("Use System.ComponentModel.PropertyChangedEventArgs.")]
+    public class PropertyChangedEventArgs : System.ComponentModel.PropertyChangedEventArgs
     {
-        public string PropertyName { get; }
         public PropertyChangedEventArgs(string propertyName)
-        {
-            PropertyName = propertyName;
-        }
+            : base(propertyName) { }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/TypeHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/TypeHandler.cs
@@ -60,7 +60,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
         protected static NotifyUpdater GetOrCreateNotifyUpdater(BSMLParser.ComponentTypeWithData componentType, BSMLParserParams parserParams)
         {
             NotifyUpdater updater = null;
-            if (parserParams.host is INotifiableHost notifyHost)
+            if (parserParams.host is System.ComponentModel.INotifyPropertyChanged notifyHost)
             {
                 updater = componentType.component.gameObject.GetComponent<NotifyUpdater>();
                 if (updater == null)

--- a/BeatSaberMarkupLanguage/ViewControllers/BSMLViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/BSMLViewController.cs
@@ -1,11 +1,11 @@
-﻿using BeatSaberMarkupLanguage.Notify;
-using HMUI;
+﻿using HMUI;
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace BeatSaberMarkupLanguage.ViewControllers
 {
-    public abstract class BSMLViewController : ViewController, INotifiableHost
+    public abstract class BSMLViewController : ViewController, INotifyPropertyChanged
     {
         public abstract string Content { get; }
 

--- a/BeatSaberMarkupLanguage/ViewControllers/TestViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/TestViewController.cs
@@ -3,13 +3,14 @@ using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Notify;
 using HMUI;
 using System.Collections.Generic;
+using System.ComponentModel;
 using TMPro;
 using static BeatSaberMarkupLanguage.Components.CustomListTableData;
 
 namespace BeatSaberMarkupLanguage.ViewControllers
 {
     [ViewDefinition("BeatSaberMarkupLanguage.Views.test.bsml")]
-    public class TestViewController : BSMLAutomaticViewController, INotifiableHost
+    public class TestViewController : BSMLAutomaticViewController, INotifyPropertyChanged
     {
         [UIValue("header")]
         public string HeaderText


### PR DESCRIPTION
Changed BSML's `INotifiableHost` to use the standard `INotifyPropertyChanged` interface.
  * `INotifiableHost` deprecated, implements `INotifyPropertyChanged`
  * `Notify.PropertyChangedEventArgs` deprecated, extends `System.ComponentModel.PropertyChangedEventArgs`
This is a breaking change for mods that use `INotifableHost` directly because the only way I can think to make the `PropertyChangedEventHandler` delegate ~~work is to `new` it in the interface and have BSML check if it's an `INotifiableHost` to use that event delegate instead of `INotifyPropertyChanged` which seems....gross~~(This does not work, classes that implement `INotifiableHost` would have to explicitly implement `System.ComponentModel.INotifyPropertyChanged`). If this next update is a big one, it seems like a good time to put this in. Any mods this change does break will just have to be recompiled and possibly add the `System.ComponentModel` namespace.

This change will allow `host` objects from assemblies that don't reference BSML to be used with the NotifyUpdater features.