### PR TITLE
Remove BS Utils and Add Localization Option

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -35,9 +35,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BS_Utils">
-      <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
-    </Reference>
     <Reference Include="HMLib">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
     </Reference>
@@ -170,6 +167,7 @@
     <Compile Include="Components\Tab.cs" />
     <Compile Include="Components\TabSelector.cs" />
     <Compile Include="Components\TextPageScrollViewRefresher.cs" />
+    <Compile Include="Config.cs" />
     <Compile Include="FloatingScreen\FloatingScreen.cs" />
     <Compile Include="FloatingScreen\FloatingScreenMoverPointer.cs" />
     <Compile Include="FontManager.cs" />

--- a/BeatSaberMarkupLanguage/Config.cs
+++ b/BeatSaberMarkupLanguage/Config.cs
@@ -1,0 +1,16 @@
+﻿using Polyglot;
+using System.Collections.Generic;
+using IPA.Config.Stores.Attributes;
+using IPA.Config.Stores.Converters;
+
+namespace BeatSaberMarkupLanguage
+{
+    public class Config
+    {
+        [UseConverter(typeof(EnumConverter<Language>))]
+        public virtual Language SelectedLanguage { get; set; }
+
+        [NonNullable, UseConverter(typeof(ListConverter<string>))]
+        public virtual List<string> PinnedMods { get; set; } = new List<string>();
+    }
+}

--- a/BeatSaberMarkupLanguage/MenuButtons/MenuButtons.cs
+++ b/BeatSaberMarkupLanguage/MenuButtons/MenuButtons.cs
@@ -78,21 +78,6 @@ namespace BeatSaberMarkupLanguage.MenuButtons
             Refresh();
         }
 
-        [UIAction("#post-parse")]
-        private void PostParse()
-        {
-            if (AnyButtons && !Plugin.config.GetBool("New", "seenMenuButton", false))
-            {
-                StartCoroutine(ShowNew());
-            }
-        }
-        IEnumerator ShowNew()
-        {
-            yield return new WaitForSeconds(1);
-            parserParams.EmitEvent("show-new");
-            Plugin.config.SetBool("New", "seenMenuButton", true);
-        }
-
         private void OnDeactivate(DeactivationType deactivationType)
         {
             parserParams.EmitEvent("close-modals");
@@ -112,7 +97,7 @@ namespace BeatSaberMarkupLanguage.MenuButtons
             get
             {
                 if (pins == null)
-                    pins = Plugin.config.GetString("Pins", "Pinned Mods").Split(',').ToList();
+                    pins = Plugin.config.PinnedMods; //.GetString("Pins", "Pinned Mods").Split(',').ToList();
                 return pins;
             }
         }
@@ -146,7 +131,7 @@ namespace BeatSaberMarkupLanguage.MenuButtons
         }
         internal void SavePins()
         {
-            Plugin.config.SetString("Pins", "Pinned Mods", string.Join(",", Pins));
+            Plugin.config.PinnedMods = Pins; //.SetString("Pins", "Pinned Mods", string.Join(",", Pins));
         }
     }
     internal class PinnedMod : INotifiableHost

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -50,7 +50,7 @@ namespace BeatSaberMarkupLanguage
                 if (File.Exists(folder))
                 {
                     string[] lines = File.ReadAllLines(folder);
-                    string pinnnedModsLine = lines.FirstOrDefault(x => x.StartsWith("Pinned Mods"));
+                    string pinnnedModsLine = lines.FirstOrDefault(x => x.StartsWith("Pinned Mods")) ?? "";
                     var splitLine = pinnnedModsLine.Split('=');
                     if (splitLine.Length > 1)
                     {

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -85,6 +85,7 @@ namespace BeatSaberMarkupLanguage
             BSMLSettings.instance.Setup();
             MenuButtons.MenuButtons.instance.Setup();
             GameplaySetup.GameplaySetup.instance.Setup();
+            Polyglot.Localization.Instance.SelectedLanguage = config.SelectedLanguage;
         }
 
         public void OnActiveSceneChanged(Scene prevScene, Scene nextScene)

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -17,6 +17,7 @@ using IPALogger = IPA.Logging.Logger;
 using IPA.Utilities;
 using HMUI;
 using IPA.Config.Stores;
+using System.IO;
 
 namespace BeatSaberMarkupLanguage
 {
@@ -40,7 +41,25 @@ namespace BeatSaberMarkupLanguage
             AnimationController.instance.InitializeLoadingAnimation();
             SceneManager.activeSceneChanged += OnActiveSceneChanged;
             config = conf.Generated<Config>();
+
+            // Old Config Migration
+
+            Task.Run(() =>
+            {
+                var folder = Path.Combine(UnityGame.UserDataPath, "BSML.ini");
+                string[] lines = File.ReadAllLines(folder);
+                string pinnnedModsLine = lines.FirstOrDefault(x => x.StartsWith("Pinned Mods"));
+                var splitLine = pinnnedModsLine.Split('=');
+                if (splitLine.Length > 1)
+                {
+                    var mods = splitLine[1].Split(',');
+                    config.PinnedMods.AddRange(mods.Where(x => !string.IsNullOrWhiteSpace(x) && x != " " && !config.PinnedMods.Contains(x)));
+                }
+                File.Delete(folder);
+            });
         }
+
+
 
         [OnStart]
         public void OnStart()

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -42,20 +42,23 @@ namespace BeatSaberMarkupLanguage
             SceneManager.activeSceneChanged += OnActiveSceneChanged;
             config = conf.Generated<Config>();
 
-            // Old Config Migration
 
+            // Old Config Migration
             Task.Run(() =>
             {
                 var folder = Path.Combine(UnityGame.UserDataPath, "BSML.ini");
-                string[] lines = File.ReadAllLines(folder);
-                string pinnnedModsLine = lines.FirstOrDefault(x => x.StartsWith("Pinned Mods"));
-                var splitLine = pinnnedModsLine.Split('=');
-                if (splitLine.Length > 1)
+                if (File.Exists(folder))
                 {
-                    var mods = splitLine[1].Split(',');
-                    config.PinnedMods.AddRange(mods.Where(x => !string.IsNullOrWhiteSpace(x) && x != " " && !config.PinnedMods.Contains(x)));
+                    string[] lines = File.ReadAllLines(folder);
+                    string pinnnedModsLine = lines.FirstOrDefault(x => x.StartsWith("Pinned Mods"));
+                    var splitLine = pinnnedModsLine.Split('=');
+                    if (splitLine.Length > 1)
+                    {
+                        var mods = splitLine[1].Split(',');
+                        config.PinnedMods.AddRange(mods.Where(x => !string.IsNullOrWhiteSpace(x) && x != " " && !config.PinnedMods.Contains(x)));
+                    }
+                    File.Delete(folder);
                 }
-                File.Delete(folder);
             });
         }
 

--- a/BeatSaberMarkupLanguage/Tags/TabSelectorTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/TabSelectorTag.cs
@@ -13,7 +13,14 @@ namespace BeatSaberMarkupLanguage.Tags
 
         public override GameObject CreateObject(Transform parent)
         {
-            TextSegmentedControl prefab = Resources.FindObjectsOfTypeAll<TextSegmentedControl>().First(x => x.transform.parent.name == "PlayerStatisticsViewController" && x.GetField<DiContainer, TextSegmentedControl>("_container") != null);
+            TextSegmentedControl prefab = Resources.FindObjectsOfTypeAll<TextSegmentedControl>().FirstOrDefault(x => x.transform.parent.name == "PlayerStatisticsViewController" && x.GetField<DiContainer, TextSegmentedControl>("_container") != null);
+            if (prefab == null)
+            {
+                Logger.log.Info("null");
+                Logger.log.Info("null");
+                Logger.log.Info("null");
+                Logger.log.Info("null");
+            }
             TextSegmentedControl textSegmentedControl = MonoBehaviour.Instantiate(prefab, parent, false);
             textSegmentedControl.name = "BSMLTabSelector";
             textSegmentedControl.SetField("_container", prefab.GetField<DiContainer, TextSegmentedControl>("_container"));

--- a/BeatSaberMarkupLanguage/Views/settings-about.bsml
+++ b/BeatSaberMarkupLanguage/Views/settings-about.bsml
@@ -2,4 +2,5 @@
   <horizontal pref-width='90'>
     <text text="Welcome to Mod Settings! If you're wondering what this new menu is, it's a seperate settings menu that mods can add to. This menu is seperated from the base game's settings in order to make it less likely to break. Basically, if you're not a mod developer then don't worry about it."></text>
   </horizontal>
+  <dropdown-list-setting id="language-dropdown" text="Language" hover-hint="Default text to this language if it exists." options="languages" value="selected-language" />
 </settings-container>

--- a/BeatSaberMarkupLanguage/manifest.json
+++ b/BeatSaberMarkupLanguage/manifest.json
@@ -5,14 +5,13 @@
     "#![BeatSaberMarkupLanguage.Resources.description.md]",
     "An XML based UI system."
   ],
-  "gameVersion": "1.11.0",
+  "gameVersion": "1.11.1",
   "icon": "BeatSaberMarkupLanguage.Resources.icon.png",
   "id": "BeatSaberMarkupLanguage",
   "name": "BeatSaberMarkupLanguage",
   "version": "1.3.5",
   "dependsOn": {
-    "BSIPA": "^4.0.5",
-    "BS Utils": "^1.4.11"
+    "BSIPA": "^4.0.5"
   },
   "links": {
     "project-home": "https://github.com/monkeymanboy/BeatSaberMarkupLanguage",

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ If you plan on adding any new dependencies which are located in the Beat Saber d
 
 ```xml
 ...
-<Reference Include="BS_Utils">
-  <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
-</Reference>
 <Reference Include="IPA.Loader">
   <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
 </Reference>


### PR DESCRIPTION
This PR includes two changes.
* Removes BS Utils as a dependency
* Adds a localization dropdown in the Mod Settings tab.

The pinned tabs are automatically migrated from the old ini file. The new config uses the built in BSIPA config.

Currently, the dropdown is in the About page, but I know you said something about adding a keyboard setting too so I'll let you decide it's final place.