### PR TITLE
Create toggle setting

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Components\NotifiableSingleton.cs" />
     <Compile Include="Components\NotifyUpdater.cs" />
     <Compile Include="Components\ScrollViewContent.cs" />
+    <Compile Include="Components\Settings\ToggleSetting.cs" />
     <Compile Include="Components\Settings\BoolSetting.cs" />
     <Compile Include="Components\Settings\ColorSetting.cs" />
     <Compile Include="Components\Settings\DropDownListSetting.cs" />
@@ -218,6 +219,7 @@
     <Compile Include="Tags\BigButtonTag.cs" />
     <Compile Include="Tags\BottomButtonPanelTag.cs" />
     <Compile Include="Tags\BSMLTag.cs" />
+    <Compile Include="Tags\Settings\ToggleSettingTag.cs" />
     <Compile Include="Tags\ButtonTag.cs" />
     <Compile Include="Tags\ClickableImageTag.cs" />
     <Compile Include="Tags\ClickableTextTag.cs" />

--- a/BeatSaberMarkupLanguage/Components/Settings/ToggleSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/ToggleSetting.cs
@@ -1,0 +1,73 @@
+﻿using TMPro;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Components.Settings
+{
+    public class ToggleSetting : GenericInteractableSetting
+    {
+        public Toggle toggle;
+        public TextMeshProUGUI text;
+
+        private bool currentValue;
+
+        public bool Value
+        {
+            get => currentValue;
+            set
+            {
+                currentValue = value;
+                toggle.isOn = value;
+            }
+        }
+
+        public string Text
+        {
+            get => text.text;
+            set => text.text = value;
+        }
+
+        public override bool interactable
+        {
+            get => toggle.interactable;
+            set => toggle.interactable = value;
+        }
+
+        public override void Setup()
+        {
+            ReceiveValue();
+        }
+
+        public override void ApplyValue()
+        {
+            if (associatedValue != null)
+                associatedValue.SetValue(Value);
+        }
+
+        public override void ReceiveValue()
+        {
+            if (associatedValue != null)
+                Value = (bool)associatedValue.GetValue();
+        }
+
+        private void OnEnable()
+        {
+            toggle.onValueChanged.AddListener(OnValueChanged);
+            toggle.isOn = currentValue;
+        }
+
+        private void OnDisable()
+        {
+            toggle.onValueChanged.RemoveListener(OnValueChanged);
+        }
+
+        private void OnValueChanged(bool value)
+        {
+            Value = value;
+
+            onChange?.Invoke(Value);
+
+            if (updateOnChange)
+                ApplyValue();
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
@@ -1,0 +1,46 @@
+﻿using BeatSaberMarkupLanguage.Components;
+using BeatSaberMarkupLanguage.Components.Settings;
+using Polyglot;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class ToggleSettingTag : BSMLTag
+    {
+        public override string[] Aliases => new[] { "toggle-setting" };
+        public virtual string PrefabToggleName => "Fullscreen";
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            GameObject gameObject = Object.Instantiate(Resources.FindObjectsOfTypeAll<Toggle>().Select(x => x.transform.parent.gameObject).First(p => p.name == PrefabToggleName), parent, false);
+            GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+
+            gameObject.name = "BSMLToggle";
+            gameObject.SetActive(false);
+
+            Object.Destroy(nameText.GetComponent<LocalizedTextMeshProUGUI>());
+
+            ToggleSetting toggleSetting = gameObject.AddComponent<ToggleSetting>();
+
+            toggleSetting.toggle = gameObject.GetComponentInChildren<Toggle>();
+            toggleSetting.toggle.interactable = true;
+            toggleSetting.toggle.onValueChanged.RemoveAllListeners();
+
+            toggleSetting.text = nameText.GetComponent<TextMeshProUGUI>();
+            toggleSetting.text.text = "Default Text";
+            toggleSetting.text.richText = true;
+            toggleSetting.text.overflowMode = TextOverflowModes.Ellipsis;
+
+            gameObject.AddComponent<ExternalComponents>().components.Add(toggleSetting.text);
+
+            gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
+
+            gameObject.SetActive(true);
+
+            return gameObject;
+        }
+    }
+}


### PR DESCRIPTION
This adds a `<toggle-setting>` tag to use the new on/off toggles from 1.12.1. Below is an example of what it looks like in the Custom Avatars menu.

![image](https://user-images.githubusercontent.com/1349975/96021522-8ef20c00-0e1d-11eb-8629-88770f207ecd.png)
