### PR TITLE
Fixed retrieving scroller instance

### DIFF
--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
@@ -79,7 +79,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
             if (componentType.data.TryGetValue("id", out string id))
             {
-                TableViewScroller scroller = tableData.tableView.GetField<TableViewScroller, TableView>("_scroller");
+                TableViewScroller scroller = tableData.tableView.GetField<TableViewScroller, TableView>("scroller");
                 parserParams.AddEvent(id + "#PageUp", scroller.PageScrollUp);
                 parserParams.AddEvent(id + "#PageDown", scroller.PageScrollDown);
             }


### PR DESCRIPTION
Fixes the invalid BSML warning when using custom lists
![afbeelding](https://user-images.githubusercontent.com/25928757/96038213-1ca61980-0e67-11eb-8461-1fd7fa11e7de.png)
