### PR TITLE
add vertical icon segmented control tag

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Tags\TextPageScrollViewTag.cs" />
     <Compile Include="Tags\TextSegmentedControlTag.cs" />
     <Compile Include="Tags\TextTag.cs" />
+    <Compile Include="Tags\VerticalIconSegmentedControlTag.cs" />
     <Compile Include="Tags\VerticalLayoutTag.cs" />
     <Compile Include="TypeHandlers\BackgroundableHandler.cs" />
     <Compile Include="TypeHandlers\ButtonArtworkHandler.cs" />

--- a/BeatSaberMarkupLanguage/Tags/VerticalIconSegmentedControlTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/VerticalIconSegmentedControlTag.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using UnityEngine;
+using HMUI;
+using IPA.Utilities;
+using Zenject;
+
+namespace BeatSaberMarkupLanguage.Tags
+{
+    public class VerticalIconSegmentedControlTag : BSMLTag
+    {
+        public override string[] Aliases => new[] { "vertical-icon-segments" };
+
+        private static IconSegmentedControl prefab;
+
+        public override GameObject CreateObject(Transform parent)
+        {
+            if (prefab == null)
+            {
+                PlatformLeaderboardViewController vc = Resources.FindObjectsOfTypeAll<PlatformLeaderboardViewController>().First();
+                prefab = vc.GetField<IconSegmentedControl, PlatformLeaderboardViewController>("_scopeSegmentedControl");
+            }
+
+            IconSegmentedControl control = MonoBehaviour.Instantiate(prefab, parent, false);
+            control.name = "BSMLVerticalIconSegmentedControl";
+            control.SetField("_container", prefab.GetField<DiContainer, IconSegmentedControl>("_container"));
+
+            RectTransform rt = control.transform as RectTransform;
+            rt.anchorMin = new Vector2(0.5f, 0.5f);
+            rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+
+            foreach (Transform transform in control.transform)
+                GameObject.Destroy(transform.gameObject);
+
+            return control.gameObject;
+        }
+    }
+}


### PR DESCRIPTION
![verticonseg](https://user-images.githubusercontent.com/14931856/97390017-123d4400-1899-11eb-9b03-e716bb8f4437.PNG)

Add a tag to create the vertical IconSegmentedControl from the leaderboards screen. Didn't really know what to use as the tag, so it's just "vertical-icon-segments" for now, since the horizontal one is "icon-segments.