### PR TITLE
Fixed NullRef in AddSettingsMenu method

### DIFF
--- a/BeatSaberMarkupLanguage/Settings/BSMLSettings.cs
+++ b/BeatSaberMarkupLanguage/Settings/BSMLSettings.cs
@@ -102,7 +102,8 @@ namespace BeatSaberMarkupLanguage.Settings
             settingsMenus.Add(settingsMenu);
             if(isInitialized)
                 settingsMenu.Setup();
-            button?.gameObject.SetActive(true);
+            if (button != null)
+                button.gameObject.SetActive(true);
         }
 
         public void RemoveSettingsMenu(object host)


### PR DESCRIPTION
This PR fixes a nullRef that could occur when adding a new Settings menu.
This was happening because `?.` bypasses the Unity lifecycle checks.

Full Rider warning:
`'?.' on a type deriving from 'UnityEngine.Object' bypasses the lifetime check on the underlying Unity engine object`