### PR TITLE
fix scrollbar not appearing for some ScrollViews

### DIFF
--- a/BeatSaberMarkupLanguage/Components/ScrollViewContent.cs
+++ b/BeatSaberMarkupLanguage/Components/ScrollViewContent.cs
@@ -1,5 +1,4 @@
 ﻿using HMUI;
-using IPA.Utilities;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
@@ -32,7 +31,7 @@ namespace BeatSaberMarkupLanguage.Components
         }
         private void UpdateScrollView()
         {
-            scrollView.SetContentHeight((transform.GetChild(0) as RectTransform).rect.height - scrollView.GetField<RectTransform, ScrollView>("_viewport").rect.height);
+            scrollView.SetContentHeight((transform.GetChild(0) as RectTransform).rect.height);
             scrollView.RefreshButtons();
         }
     }

--- a/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ScrollViewTag.cs
@@ -54,7 +54,7 @@ namespace BeatSaberMarkupLanguage.Tags
             verticalLayout.childAlignment = TextAnchor.UpperCenter;
 
             RectTransform rectTransform = parentObj.transform as RectTransform;
-            rectTransform.anchorMin = new Vector2(0, 0);
+            rectTransform.anchorMin = new Vector2(0, 1);
             rectTransform.anchorMax = new Vector2(1, 1);
             rectTransform.sizeDelta = new Vector2(0, 0);
             rectTransform.pivot = new Vector2(0.5f, 1);


### PR DESCRIPTION
GetContentHeight sets the scrollbar to be active only if the content height that was passed via the parameter is greater than the viewport height. Because of that, the scrollbar would not appear if the content's rect size was less than 2 times the viewport's height before this fix.

The issue occurred because the y-min and y-max anchors of the content container were at 0 and 1 respectively, so it would span the entire height of the viewport. The requested content height passed to GetContentHeight had to subtract the viewport's height to get the correct size delta, but that would mess up the scrollbar active calculation because it expects the actual height of the content container, not a size delta.

I've only tested this on stuff that I've been working on, so I don't know if this would negatively affect other mods.