### PR TITLE
fix attributes not working on inherited properties

### DIFF
--- a/BeatSaberMarkupLanguage/BSMLParser.cs
+++ b/BeatSaberMarkupLanguage/BSMLParser.cs
@@ -189,7 +189,7 @@ namespace BeatSaberMarkupLanguage
 
                 foreach (PropertyInfo propertyInfo in host.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
                 {
-                    UIValue uivalue = propertyInfo.GetCustomAttributes(typeof(UIValue), true).FirstOrDefault() as UIValue;
+                    UIValue uivalue = Attribute.GetCustomAttributes(propertyInfo, typeof(UIValue), true).FirstOrDefault() as UIValue;
                     string propName = propertyInfo.Name;
                     string uiValueName = null;
                     if (uivalue != null)


### PR DESCRIPTION
Custom attributes didn't work on properties of an abstract or a base class, since PropertyInfo.GetCustomAttributes ignores the `inherit` flag [(as stated in the Remarks section of the docs)](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.getcustomattributes?redirectedfrom=MSDN&view=net-5.0#System_Reflection_MemberInfo_GetCustomAttributes_System_Type_System_Boolean_). Instead, the docs say to use the static [System.Attribute.GetCustomAttributes](https://docs.microsoft.com/en-us/dotnet/api/system.attribute.getcustomattributes?view=net-5.0#System_Attribute_GetCustomAttributes_System_Reflection_MemberInfo_System_Type_System_Boolean_) method for these situations.