### PR TITLE
Fixed possible exception when handling scrollview after parse

### DIFF
--- a/BeatSaberMarkupLanguage/Components/BSMLScrollableContainer.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollableContainer.cs
@@ -81,6 +81,11 @@ namespace BeatSaberMarkupLanguage.Components
 
         public void RefreshBindings()
         {
+            if (_buttonBinder == null)
+            {
+                return;
+            }
+
             _buttonBinder.ClearBindings();
             if (PageUpButton != null)
                 _buttonBinder.AddBinding(PageUpButton, PageUpButtonPressed);


### PR DESCRIPTION
When a scrollview is inactive (for example: it has the active="false" attribute or the containing container is marked as inactive), then it would throw a nullReference exception when trying to handle said scrollview after parsing. This PR supposedly fixes that.