### PR TITLE
Fix FloatingScreen handle rotation

### DIFF
--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
@@ -137,6 +137,7 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
                 handle = GameObject.CreatePrimitive(PrimitiveType.Cube);
 
                 handle.transform.SetParent(transform);
+                handle.transform.localRotation = Quaternion.identity;
                 UpdateHandle();
 
                 screenMover.Init(this);


### PR DESCRIPTION
Quick fix for the floating screen handle's rotation not matching the floating screen when it is first created.
![old](https://user-images.githubusercontent.com/14931856/102026317-08d93f80-3d52-11eb-8b90-cf03fa0bf97e.PNG)

![new](https://user-images.githubusercontent.com/14931856/102026341-332afd00-3d52-11eb-83c5-117c49a1084b.PNG)
