### PR TITLE
Localization Support

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -313,11 +313,13 @@
     <Compile Include="ViewControllers\BSMLResourceViewController.cs" />
     <Compile Include="ViewControllers\BSMLViewController.cs" />
     <Compile Include="ViewControllers\HotReloadableViewController.cs" />
+    <Compile Include="ViewControllers\LocalizationTestViewController.cs" />
     <Compile Include="ViewControllers\TestViewController.cs" />
     <Compile Include="ViewControllers\WatcherGroup.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\test.bsml" />
+    <EmbeddedResource Include="Views\localization-test.bsml" />
     <EmbeddedResource Include="manifest.json" />
     <EmbeddedResource Include="Views\settings-buttons.bsml" />
     <EmbeddedResource Include="Views\settings-list.bsml" />

--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -53,6 +53,9 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
+    <Reference Include="Polyglot">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Polyglot.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>
@@ -145,6 +148,7 @@
     <Compile Include="Components\ExternalComponents.cs" />
     <Compile Include="Components\FormattableText.cs" />
     <Compile Include="Components\Glowable.cs" />
+    <Compile Include="Components\LocalizableText.cs" />
     <Compile Include="Components\ModalColorPicker.cs" />
     <Compile Include="Components\ModalKeyboard.cs" />
     <Compile Include="Components\NotifiableSingleton.cs" />
@@ -299,6 +303,7 @@
     <Compile Include="TypeHandlers\StrokableHandler.cs" />
     <Compile Include="TypeHandlers\TabHandler.cs" />
     <Compile Include="TypeHandlers\TabSelectorHandler.cs" />
+    <Compile Include="TypeHandlers\LocalizedTextMeshProUGUIHandler.cs" />
     <Compile Include="TypeHandlers\TextMeshProUGUIHandler.cs" />
     <Compile Include="TypeHandlers\TextPageScrollViewHandler.cs" />
     <Compile Include="TypeHandlers\TextSegmentedControlHandler.cs" />

--- a/BeatSaberMarkupLanguage/Components/LocalizableText.cs
+++ b/BeatSaberMarkupLanguage/Components/LocalizableText.cs
@@ -1,0 +1,14 @@
+﻿using Polyglot;
+using TMPro;
+
+namespace BeatSaberMarkupLanguage.Components
+{
+    public class LocalizableText : LocalizedTextMeshProUGUI
+    {
+        public TextMeshProUGUI TextMesh
+        {
+            get => localizedComponent;
+            set => localizedComponent = value;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/Components/Tab.cs
+++ b/BeatSaberMarkupLanguage/Components/Tab.cs
@@ -5,6 +5,8 @@ namespace BeatSaberMarkupLanguage.Components
     public class Tab : MonoBehaviour
     {
         private string tabName;
+        private string tabKey;
+
         public string TabName
         {
             get => tabName;
@@ -24,6 +26,17 @@ namespace BeatSaberMarkupLanguage.Components
                 selector?.Refresh();
             }
         }
+
+        public string TabKey
+        {
+            get => tabKey;
+            set
+            {
+                tabKey = value;
+                selector?.Refresh();
+            }
+        }
+
         public TabSelector selector;
     }
 }

--- a/BeatSaberMarkupLanguage/Components/TabSelector.cs
+++ b/BeatSaberMarkupLanguage/Components/TabSelector.cs
@@ -1,5 +1,6 @@
 ﻿using BeatSaberMarkupLanguage.Parser;
 using HMUI;
+using Polyglot;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -77,7 +78,7 @@ namespace BeatSaberMarkupLanguage.Components
             List<Tab> visibleTabs = tabs.Where(x => x.IsVisible).ToList();
             if (PageCount == -1)
             {
-                textSegmentedControl.SetTexts(visibleTabs.Select(x => x.TabName).ToArray());
+                SetSegmentedControlTexts(visibleTabs);
             }
             else
             {
@@ -85,7 +86,7 @@ namespace BeatSaberMarkupLanguage.Components
                     currentPage = 0;
                 if(currentPage > (visibleTabs.Count - 1) / pageCount)
                     currentPage = (visibleTabs.Count - 1) / pageCount;
-                textSegmentedControl.SetTexts(visibleTabs.Select(x => x.TabName).Skip(PageCount * currentPage).Take(PageCount).ToArray());
+                SetSegmentedControlTexts(visibleTabs.Skip(PageCount * currentPage).Take(PageCount).ToList());
                 if(leftButton != null)
                     leftButton.interactable = currentPage > 0;
                 if(rightButton != null)
@@ -102,6 +103,26 @@ namespace BeatSaberMarkupLanguage.Components
                     cells[i].SetSelected(i == selectCellNumber, SelectableCell.TransitionType.Instant, this, ignoreCurrentValue: true);
                 }*/
             }
+        }
+        private void SetSegmentedControlTexts(List<Tab> tabs)
+        {
+            var texts = new string[tabs.Count];
+
+            for (int i = 0; i < tabs.Count; i++)
+            {
+                Tab tab = tabs[i];
+
+                if (!string.IsNullOrEmpty(tab.TabKey))
+                {
+                    texts[i] = Localization.Get(tab.TabKey);
+                }
+                else
+                {
+                    texts[i] = tab.TabName;
+                }
+            }
+
+            textSegmentedControl.SetTexts(texts);
         }
         private void PageLeft()
         {

--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -18,6 +18,7 @@ using IPA.Utilities;
 using IPA.Config.Stores;
 using System.IO;
 using Zenject;
+using HMUI;
 
 namespace BeatSaberMarkupLanguage
 {
@@ -106,7 +107,8 @@ namespace BeatSaberMarkupLanguage
         {
             //GameplaySetup.GameplaySetup.instance.AddTab("Test", "BeatSaberMarkupLanguage.Views.gameplay-setup-test.bsml", GameplaySetupTest.instance);
             //BSMLSettings.instance.AddSettingsMenu("Test", "BeatSaberMarkupLanguage.Views.settings-test.bsml", SettingsTest.instance);
-            //SharedCoroutineStarter.instance.StartCoroutine(PresentTest());
+            //SharedCoroutineStarter.instance.StartCoroutine(PresentTest<TestViewController>());
+            //SharedCoroutineStarter.instance.StartCoroutine(PresentTest<LocalizationTestViewController>());
             //MenuButtons.MenuButtons.instance.RegisterButton(new MenuButtons.MenuButton("test", () => MenuButtons.MenuButtons.instance.RegisterButton(new MenuButtons.MenuButton("test2",null))));
             BSMLSettings.instance.Setup();
             MenuButtons.MenuButtons.instance.Setup();
@@ -131,13 +133,13 @@ namespace BeatSaberMarkupLanguage
         }
 
         //It's just for testing so don't yell at me
-        private IEnumerator PresentTest()
+        private IEnumerator PresentTest<T>() where T : ViewController
         {
             yield return new WaitForSeconds(1);
-            TestViewController testViewController = BeatSaberUI.CreateViewController<TestViewController>();
-            //FloatingScreen.FloatingScreen floatingScreen = FloatingScreen.FloatingScreen.CreateFloatingScreen(new Vector2(400, 200), true, Vector3.zero, Quaternion.identity);
-            //floatingScreen.SetRootViewController(testViewController, ViewController.AnimationType.None);
-            //Resources.FindObjectsOfTypeAll<MainFlowCoordinator>().First().InvokeMethod<object, FlowCoordinator>("PresentViewController", new object[] { testViewController, null, ViewController.AnimationDirection.Horizontal, false });
+            ViewController testViewController = BeatSaberUI.CreateViewController<T>();
+            FloatingScreen.FloatingScreen floatingScreen = FloatingScreen.FloatingScreen.CreateFloatingScreen(new Vector2(400, 200), true, Vector3.zero, Quaternion.identity);
+            floatingScreen.SetRootViewController(testViewController, ViewController.AnimationType.None);
+            Resources.FindObjectsOfTypeAll<MainFlowCoordinator>().First().InvokeMethod<object, FlowCoordinator>("PresentViewController", new object[] { testViewController, null, ViewController.AnimationDirection.Horizontal, false });
         }
     }
 }

--- a/BeatSaberMarkupLanguage/Tags/BSMLTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/BSMLTag.cs
@@ -1,4 +1,8 @@
-﻿using UnityEngine;
+﻿using BeatSaberMarkupLanguage.Components;
+using Polyglot;
+using System;
+using TMPro;
+using UnityEngine;
 
 namespace BeatSaberMarkupLanguage.Tags
 {
@@ -10,5 +14,34 @@ namespace BeatSaberMarkupLanguage.Tags
 
         public abstract GameObject CreateObject(Transform parent);
         public virtual void Setup() { }
+
+        protected LocalizableText CreateLocalizableText(GameObject gameObject)
+        {
+            TextMeshProUGUI textMesh = gameObject.GetComponent<TextMeshProUGUI>();
+
+            if (!textMesh) throw new InvalidOperationException("CreateLocalizableText should only be called if a TextMeshProUGUI instance already exists on the GameObject");
+
+            bool wasActive = gameObject.activeSelf;
+            gameObject.SetActive(false);
+
+            LocalizableText localizableText = gameObject.AddComponent<LocalizableText>();
+
+            localizableText.enabled = false;
+            localizableText.TextMesh = gameObject.GetComponent<TextMeshProUGUI>();
+
+            gameObject.SetActive(wasActive);
+
+            return localizableText;
+        }
+
+        protected LocalizedTextMeshProUGUI ConfigureLocalizedText(GameObject gameObject)
+        {
+            LocalizedTextMeshProUGUI localizedText = gameObject.GetComponent<LocalizedTextMeshProUGUI>();
+
+            localizedText.enabled = false;
+            localizedText.Key = string.Empty;
+
+            return localizedText;
+        }
     }
 }

--- a/BeatSaberMarkupLanguage/Tags/ButtonTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ButtonTag.cs
@@ -1,5 +1,6 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using HMUI;
+using Polyglot;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -20,11 +21,15 @@ namespace BeatSaberMarkupLanguage.Tags
             Button button = MonoBehaviour.Instantiate(buttonPrefab, parent, false);
             button.name = "BSMLButton";
             button.interactable = true;
-            Polyglot.LocalizedTextMeshProUGUI localizer = button.GetComponentInChildren<Polyglot.LocalizedTextMeshProUGUI>(true);
-            if (localizer != null)
-                GameObject.Destroy(localizer);
+
             ExternalComponents externalComponents = button.gameObject.AddComponent<ExternalComponents>();
-            TextMeshProUGUI textMesh = button.GetComponentInChildren<TextMeshProUGUI>();
+            GameObject textObject = button.transform.Find("Content/Text").gameObject;
+
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(textObject);
+            externalComponents.components.Add(localizedText);
+
+            TextMeshProUGUI textMesh = textObject.GetComponent<TextMeshProUGUI>();
+            textMesh.text = "Default Text";
             textMesh.richText = true;
             externalComponents.components.Add(textMesh);
 

--- a/BeatSaberMarkupLanguage/Tags/ClickableTextTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ClickableTextTag.cs
@@ -23,6 +23,8 @@ namespace BeatSaberMarkupLanguage.Tags
             clickableText.color = Color.white;
             clickableText.rectTransform.sizeDelta = new Vector2(90, 8);
 
+            CreateLocalizableText(gameObject);
+
             gameObject.SetActive(true);
             return gameObject;
         }

--- a/BeatSaberMarkupLanguage/Tags/ModifierTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/ModifierTag.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using HMUI;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -18,16 +19,28 @@ namespace BeatSaberMarkupLanguage.Tags
             baseModifier.name = "BSMLModifier";
 
             GameObject gameObject = baseModifier.gameObject;
+            gameObject.SetActive(false);
 
             MonoBehaviour.Destroy(baseModifier);
             MonoBehaviour.Destroy(gameObject.GetComponent<HoverHint>());
             
-            ExternalComponents externalComponents = gameObject.AddComponent<ExternalComponents>();
-            externalComponents.components.Add(gameObject.GetComponentInChildren<TextMeshProUGUI>());
-            externalComponents.components.Add(gameObject.transform.Find("Icon").GetComponent<Image>());
+            GameObject nameText = gameObject.transform.Find("Name").gameObject;
+            TextMeshProUGUI text = nameText.GetComponent<TextMeshProUGUI>();
+            text.text = "Default Text";
+
+            LocalizableText localizedText = CreateLocalizableText(nameText);
+            localizedText.MaintainTextAlignment = true;
+
+            List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(text);
+            externalComponents.Add(localizedText);
+            externalComponents.Add(gameObject.transform.Find("Icon").GetComponent<Image>());
 
             ToggleSetting toggleSetting = gameObject.AddComponent<ToggleSetting>();
             toggleSetting.toggle = gameObject.GetComponent<Toggle>();
+            toggleSetting.toggle.onValueChanged.RemoveAllListeners();
+
+            gameObject.SetActive(true);
 
             return gameObject;
         }

--- a/BeatSaberMarkupLanguage/Tags/Settings/ColorSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ColorSettingTag.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using Polyglot;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -34,10 +35,15 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
             GameObject.Destroy(valuePick.GetComponentsInChildren<TextMeshProUGUI>().First().gameObject);
             colorSetting.editButton = valuePick.GetComponentsInChildren<Button>().Last();
 
-            TextMeshProUGUI text = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+            GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
+
+            TextMeshProUGUI text = nameText.GetComponent<TextMeshProUGUI>();
             text.text = "Default Text";
-            gameObject.AddComponent<ExternalComponents>().components.Add(text);
-            MonoBehaviour.Destroy(text.GetComponent<LocalizedTextMeshProUGUI>());
+
+            List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(text);
+            externalComponents.Add(localizedText);
 
             gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
             

--- a/BeatSaberMarkupLanguage/Tags/Settings/DropdownListSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/DropdownListSettingTag.cs
@@ -3,9 +3,8 @@ using BeatSaberMarkupLanguage.Components.Settings;
 using HMUI;
 using IPA.Utilities;
 using Polyglot;
-using System;
+using System.Collections.Generic;
 using System.Linq;
-using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using VRUIControls;
@@ -34,16 +33,20 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
             dropdown.GetComponentInChildren<VRGraphicRaycaster>(true).SetField("_physicsRaycaster", BeatSaberUI.PhysicsRaycasterWithCache);
             dropdown.GetComponentInChildren<ModalView>(true).SetField("_container", BeatSaberUI.DiContainer);
 
-            ExternalComponents externalComponents = dropdown.gameObject.AddComponent<ExternalComponents>();
-
             GameObject labelObject = gameObject.transform.Find("Label").gameObject;
-            MonoBehaviour.Destroy(labelObject.GetComponent<LocalizedTextMeshProUGUI>());
-            externalComponents.components.Add(gameObject.transform.Find("Label").GetComponent<CurvedTextMeshPro>());
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(labelObject);
+
+            CurvedTextMeshPro textMesh = labelObject.GetComponent<CurvedTextMeshPro>();
+            textMesh.text = "Default Text";
 
             LayoutElement layoutElement = gameObject.AddComponent<LayoutElement>();
             layoutElement.preferredHeight = 8;
             layoutElement.preferredWidth = 90;
-            externalComponents.components.Add(layoutElement);
+
+            List<Component> externalComponents = dropdown.gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(textMesh);
+            externalComponents.Add(localizedText);
+            externalComponents.Add(layoutElement);
 
             DropDownListSetting dropDownListSetting = dropdown.gameObject.AddComponent<DropDownListSetting>();
             

--- a/BeatSaberMarkupLanguage/Tags/Settings/GenericSliderSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/GenericSliderSettingTag.cs
@@ -3,6 +3,7 @@ using BeatSaberMarkupLanguage.Components.Settings;
 using HMUI;
 using Polyglot;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -32,10 +33,15 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
 
             MonoBehaviour.Destroy(baseSetting);
 
-            TextMeshProUGUI text = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+            GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
+
+            TextMeshProUGUI text = nameText.GetComponent<TextMeshProUGUI>();
             text.text = "Default Text";
-            gameObject.AddComponent<ExternalComponents>().components.Add(text);
-            MonoBehaviour.Destroy(text.GetComponent<LocalizedTextMeshProUGUI>());
+
+            List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(text);
+            externalComponents.Add(localizedText);
 
             gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
 

--- a/BeatSaberMarkupLanguage/Tags/Settings/IncDecSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/IncDecSettingTag.cs
@@ -1,7 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using Polyglot;
-using System;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -28,11 +28,16 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
             (gameObject.transform.GetChild(1) as RectTransform).sizeDelta = new Vector2(40, 0);
             boolSetting.text.overflowMode = TextOverflowModes.Ellipsis;
 
-            TextMeshProUGUI text = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+            GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
+
+            TextMeshProUGUI text = nameText.GetComponent<TextMeshProUGUI>();
             text.text = "Default Text";
             text.richText = true;
-            gameObject.AddComponent<ExternalComponents>().components.Add(text);
-            MonoBehaviour.Destroy(text.GetComponent<LocalizedTextMeshProUGUI>());
+
+            List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(text);
+            externalComponents.Add(localizedText);
 
             gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
 

--- a/BeatSaberMarkupLanguage/Tags/Settings/StringSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/StringSettingTag.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using Polyglot;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -32,12 +33,17 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
             stringSetting.text.richText = true;
             stringSetting.editButton = valuePick.GetComponentsInChildren<Button>().Last();
             stringSetting.boundingBox = valuePick as RectTransform;
-            
-            TextMeshProUGUI text = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+
+            GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
+
+            TextMeshProUGUI text = nameText.GetComponent<TextMeshProUGUI>();
             text.text = "Default Text";
-            gameObject.AddComponent<ExternalComponents>().components.Add(text);
-            MonoBehaviour.Destroy(text.GetComponent<LocalizedTextMeshProUGUI>());
-            
+
+            List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(text);
+            externalComponents.Add(localizedText);
+
             gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
             stringSetting.text.alignment = TextAlignmentOptions.MidlineRight;
             stringSetting.text.enableWordWrapping = false;

--- a/BeatSaberMarkupLanguage/Tags/Settings/SubmenuTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/SubmenuTag.cs
@@ -1,5 +1,4 @@
 ﻿using BeatSaberMarkupLanguage.Components;
-using BeatSaberMarkupLanguage.Components.Settings;
 using BeatSaberMarkupLanguage.Settings;
 using HMUI;
 using System.Linq;
@@ -26,6 +25,8 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
             clickableText.color = Color.white;
             clickableText.rectTransform.sizeDelta = new Vector2(90, 8);
 
+            LocalizableText localizedText = CreateLocalizableText(gameObj);
+
             ViewController submenuController = BeatSaberUI.CreateViewController<ViewController>();
             SettingsMenu.SetupViewControllerTransform(submenuController);
 
@@ -39,6 +40,7 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
             ExternalComponents externalComponents = submenuController.gameObject.AddComponent<ExternalComponents>();
             externalComponents.components.Add(clickableText);
             externalComponents.components.Add(clickableText.rectTransform);
+            externalComponents.components.Add(localizedText);
 
             gameObj.SetActive(true);
             return submenuController.gameObject;

--- a/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using Polyglot;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -22,8 +23,6 @@ namespace BeatSaberMarkupLanguage.Tags
             gameObject.name = "BSMLToggle";
             gameObject.SetActive(false);
 
-            Object.Destroy(nameText.GetComponent<LocalizedTextMeshProUGUI>());
-
             ToggleSetting toggleSetting = gameObject.AddComponent<ToggleSetting>();
 
             toggleSetting.toggle = gameObject.GetComponentInChildren<Toggle>();
@@ -31,12 +30,16 @@ namespace BeatSaberMarkupLanguage.Tags
             toggleSetting.toggle.isOn = false;
             toggleSetting.toggle.onValueChanged.RemoveAllListeners();
 
+            LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
+
             toggleSetting.text = nameText.GetComponent<TextMeshProUGUI>();
             toggleSetting.text.text = "Default Text";
             toggleSetting.text.richText = true;
             toggleSetting.text.overflowMode = TextOverflowModes.Ellipsis;
 
-            gameObject.AddComponent<ExternalComponents>().components.Add(toggleSetting.text);
+            List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
+            externalComponents.Add(toggleSetting.text);
+            externalComponents.Add(localizedText);
 
             gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
 

--- a/BeatSaberMarkupLanguage/Tags/TextPageScrollViewTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/TextPageScrollViewTag.cs
@@ -1,10 +1,10 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using HMUI;
 using IPA.Utilities;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace BeatSaberMarkupLanguage.Tags
 {
@@ -17,10 +17,18 @@ namespace BeatSaberMarkupLanguage.Tags
             TextPageScrollView scrollView = MonoBehaviour.Instantiate(Resources.FindObjectsOfTypeAll<ReleaseInfoViewController>().First().GetField<TextPageScrollView, ReleaseInfoViewController>("_textPageScrollView"), parent);
             scrollView.name = "BSMLTextPageScrollView";
             scrollView.enabled = true;
+
             TextMeshProUGUI textMesh = scrollView.GetField<TextMeshProUGUI, TextPageScrollView>("_text");
-            
+            textMesh.text = "Default Text";
+
+            LocalizableText localizedText = CreateLocalizableText(textMesh.gameObject);
+
             textMesh.gameObject.AddComponent<TextPageScrollViewRefresher>().scrollView = scrollView;
-            scrollView.gameObject.AddComponent<ExternalComponents>().components.Add(textMesh);
+
+            List<Component> components = scrollView.gameObject.AddComponent<ExternalComponents>().components;
+            components.Add(textMesh);
+            components.Add(localizedText);
+
             return scrollView.gameObject;
         }
     }

--- a/BeatSaberMarkupLanguage/Tags/TextTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/TextTag.cs
@@ -21,9 +21,12 @@ namespace BeatSaberMarkupLanguage.Tags
             textMesh.font = MonoBehaviour.Instantiate(font);
             textMesh.fontSize = 4;
             textMesh.color = Color.white;
+            textMesh.text = "Default Text";
 
             textMesh.rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
             textMesh.rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
+
+            CreateLocalizableText(gameObj);
 
             return gameObj;
         }

--- a/BeatSaberMarkupLanguage/TypeHandlers/LocalizedTextMeshProUGUIHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/LocalizedTextMeshProUGUIHandler.cs
@@ -1,0 +1,22 @@
+﻿using Polyglot;
+using System;
+using System.Collections.Generic;
+
+namespace BeatSaberMarkupLanguage.TypeHandlers
+{
+    [ComponentHandler(typeof(LocalizedTextMeshProUGUI))]
+    public class LocalizedTextMeshProUGUIHandler : TypeHandler<LocalizedTextMeshProUGUI>
+    {
+        public override Dictionary<string, string[]> Props => new Dictionary<string, string[]>()
+        {
+            { "key", new[] { "key" } },
+            { "maintainTextAlignment", new[] { "maintain-text-alignment" } }
+        };
+
+        public override Dictionary<string, Action<LocalizedTextMeshProUGUI, string>> Setters => new Dictionary<string, Action<LocalizedTextMeshProUGUI, string>>()
+        {
+            {"key", new Action<LocalizedTextMeshProUGUI, string>((localizedText, value) => { localizedText.Key = value; localizedText.enabled = true; }) },
+            {"maintainTextAlignment", new Action<LocalizedTextMeshProUGUI, string>((localizedText, value) => localizedText.MaintainTextAlignment = Parse.Bool(value)) }
+        };
+    }
+}

--- a/BeatSaberMarkupLanguage/TypeHandlers/RectTransformHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/RectTransformHandler.cs
@@ -1,5 +1,6 @@
 ﻿using HMUI;
 using IPA.Utilities;
+using Polyglot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,6 +24,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             { "pivotX", new[]{ "pivot-x" } },
             { "pivotY", new[]{ "pivot-y" } },
             { "hoverHint", new[]{ "hover-hint" } },
+            { "hoverHintKey", new[]{ "hover-hint-key" } },
             { "active", new[]{ "active" } }
         };
 
@@ -39,6 +41,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             {"pivotX", new Action<RectTransform, string>((component, value) => component.pivot = new Vector2(Parse.Float(value), component.pivot.y)) },
             {"pivotY", new Action<RectTransform, string>((component, value) => component.pivot = new Vector2(component.pivot.x, Parse.Float(value))) },
             {"hoverHint", new Action<RectTransform, string>(AddHoverHint) },
+            {"hoverHintKey", new Action<RectTransform, string>(AddHoverHintKey) },
             {"active", new Action<RectTransform, string>((component, value) => component.gameObject.SetActive(Parse.Bool(value))) }
         };
 
@@ -47,6 +50,11 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             HoverHint hover = rectTransform.gameObject.AddComponent<HoverHint>();
             hover.text = text;
             hover.SetField("_hoverHintController", Resources.FindObjectsOfTypeAll<HoverHintController>().First());
+        }
+
+        private void AddHoverHintKey(RectTransform rectTransform, string key)
+        {
+            AddHoverHint(rectTransform, Localization.Get(key));
         }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/TabHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/TabHandler.cs
@@ -9,12 +9,14 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
     {
         public override Dictionary<string, string[]> Props => new Dictionary<string, string[]>()
         {
-            { "tabName", new[]{"tab-name"} }
+            { "tabName", new[] { "tab-name" } },
+            { "tabNameKey", new[] { "tab-name-key" } }
         };
 
         public override Dictionary<string, Action<Tab, string>> Setters => new Dictionary<string, Action<Tab, string>>()
         {
-            {"tabName", new Action<Tab, string>((component, value) => component.TabName = !string.IsNullOrEmpty(value) ? value : throw new ArgumentNullException("tabName cannot be null or empty for Tab")) }
+            {"tabName", new Action<Tab, string>((component, value) => component.TabName = !string.IsNullOrEmpty(value) ? value : throw new ArgumentNullException("tabName cannot be null or empty for Tab")) },
+            {"tabNameKey", new Action<Tab, string>((component, value) => component.TabKey = value) }
         };
     }
 }

--- a/BeatSaberMarkupLanguage/ViewControllers/LocalizationTestViewController.cs
+++ b/BeatSaberMarkupLanguage/ViewControllers/LocalizationTestViewController.cs
@@ -1,0 +1,13 @@
+﻿using BeatSaberMarkupLanguage.Attributes;
+using System.Collections.Generic;
+
+namespace BeatSaberMarkupLanguage.ViewControllers
+{
+    public class LocalizationTestViewController : BSMLResourceViewController
+    {
+        public override string ResourceName => "BeatSaberMarkupLanguage.Views.localization-test.bsml";
+
+        [UIValue("contents")]
+        public List<object> contents = new List<object>(new[] { "one", "two", "three" });
+    }
+}

--- a/BeatSaberMarkupLanguage/Views/localization-test.bsml
+++ b/BeatSaberMarkupLanguage/Views/localization-test.bsml
@@ -1,0 +1,36 @@
+﻿<bg>
+  <tab-selector tab-tag='localization'></tab-selector>
+  <tab tags='localization' tab-name-key='LANGUAGE_EN'>
+    <settings-container>
+      <color-setting/>
+      <dropdown-list-setting options='contents'/>
+      <increment-setting/>
+      <list-setting options='contents'/>
+      <slider-setting/>
+      <string-setting/>
+      <toggle-setting/>
+      <color-setting key='BUTTON_CAMPAIGN'/>
+      <dropdown-list-setting key='BUTTON_SOLO' options='contents'/>
+      <increment-setting key='BUTTON_PARTY'/>
+      <list-setting key='BUTTON_HOW_TO_PLAY' options='contents'/>
+      <slider-setting key='BUTTON_CREDITS'/>
+      <string-setting key='BUTTON_SETTINGS'/>
+      <toggle-setting key='BUTTON_PLAYER_SETTINGS'/>
+    </settings-container>
+  </tab>
+  <tab tags='localization' tab-name-key='LANGUAGE_SC'>
+    <vertical>
+      <button/>
+      <clickable-text/>
+      <modifier/>
+      <text/>
+      <button key='BUTTON_QUIT'/>
+      <clickable-text key='BUTTON_BASICS'/>
+      <modifier key='BUTTON_SCORE_SYSTEM'/>
+      <text key='BUTTON_MENU'/>
+    </vertical>
+  </tab>
+  <tab tags='localization' tab-name-key='HEALTH_AND_SAFETY_WARNING_TITLE'>
+    <text-page key='HEALTH_AND_SAFETY_WARNING_CONTENT'/>
+  </tab>
+</bg>


### PR DESCRIPTION
Adds localization support to all tags to which text can be assigned via XML and a test view controller to make sure everything works as expected.

**Updated Tags:**
- `color-setting`
- `dropdown-list-setting`
- `increment-setting`/`list-setting`
- `slider-setting`/`list-slider-setting`
- `string-setting`
- `settings-submenu`
- `toggle-setting`
- `button`
- `clickable-text`
- `modifier`
- `text-page`
- `text`

**New Attributes:**
- `key` for `text`
- `tab-name-key` for `tab-name`
- `hover-hint-key` for `hover-hint`