### PR TITLE
Fixed full screen bug

### DIFF
--- a/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
@@ -12,6 +12,7 @@ namespace BeatSaberMarkupLanguage.Tags
     public class ToggleSettingTag : BSMLTag
     {
         private GameObject toggleTemplate;
+        private BoolSettingsController templateController;
 
         public override string[] Aliases => new[] { "toggle-setting", "bool-setting", "checkbox-setting", "checkbox" };
         public virtual string PrefabToggleName => "Fullscreen";
@@ -19,10 +20,16 @@ namespace BeatSaberMarkupLanguage.Tags
         public override GameObject CreateObject(Transform parent)
         {
             if (toggleTemplate == null)
+            {
                 toggleTemplate = Resources.FindObjectsOfTypeAll<Toggle>().Select(x => x.transform.parent.gameObject).First(p => p.name == PrefabToggleName);
+                templateController = toggleTemplate.GetComponent<BoolSettingsController>();
+            }
+
+            templateController.enabled = false;
             GameObject gameObject = Object.Instantiate(toggleTemplate, parent, false);
             GameObject nameText = gameObject.transform.Find("NameText").gameObject;
             Object.Destroy(gameObject.GetComponent<BoolSettingsController>());
+            templateController.enabled = true;
 
             gameObject.name = "BSMLToggle";
             gameObject.SetActive(false);


### PR DESCRIPTION
This PR fixes the full screen bug where the game would "randomly" unfullscreen.

The actual cause was BSML using the "Fullscreen" toggle as the toggle template, and instantiating it with the BoolSettingsController still active would cause it to reset the value.

Huge shout out to @Meivyn for giving me the info in order to figure this out
![fullscreen_bug](https://user-images.githubusercontent.com/41306347/111100702-b1986600-851e-11eb-94a6-43e72a18c307.png)
