### PR TITLE
Fix full screen bug... part 2

### DIFF
--- a/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
@@ -13,6 +13,7 @@ namespace BeatSaberMarkupLanguage.Tags
     {
         private GameObject toggleTemplate;
         private BoolSettingsController templateController;
+        private Toggle templateControllerToggle;
 
         public override string[] Aliases => new[] { "toggle-setting", "bool-setting", "checkbox-setting", "checkbox" };
         public virtual string PrefabToggleName => "Fullscreen";
@@ -23,13 +24,16 @@ namespace BeatSaberMarkupLanguage.Tags
             {
                 toggleTemplate = Resources.FindObjectsOfTypeAll<Toggle>().Select(x => x.transform.parent.gameObject).First(p => p.name == PrefabToggleName);
                 templateController = toggleTemplate.GetComponent<BoolSettingsController>();
+                templateControllerToggle = templateController.GetComponentInChildren<Toggle>();
             }
 
             templateController.enabled = false;
+            templateControllerToggle.isOn = false;
             GameObject gameObject = Object.Instantiate(toggleTemplate, parent, false);
             GameObject nameText = gameObject.transform.Find("NameText").gameObject;
             Object.Destroy(gameObject.GetComponent<BoolSettingsController>());
             templateController.enabled = true;
+            templateControllerToggle.isOn = true;
 
             gameObject.name = "BSMLToggle";
             gameObject.SetActive(false);


### PR DESCRIPTION
This effectively complements the fullscreen bug fix we found with @Auros.

The issue occurs as soon as you go through the official settings before instantiating your toggles, go back without clicking OK, and then go through the BSML settings view. The switches are stuck in the state the fullscreen setting was when you opened the settings. It also causes the fullscreen switch to toggle along with ours, which again results in an unfullscreen.

The toggle should also be disabled before instantiating the object. 

Here is a video of this issue: https://youtu.be/GUZkOZC-rVg

Related to https://github.com/ToniMacaroni/SaberFactory/issues/2 and https://github.com/ToniMacaroni/SaberFactoryV2/issues/21.

