### PR TITLE
Fix toggle tags sometimes being created in a bad state

### DIFF
--- a/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
@@ -1,5 +1,6 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
+using HMUI;
 using Polyglot;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,8 +13,6 @@ namespace BeatSaberMarkupLanguage.Tags
     public class ToggleSettingTag : BSMLTag
     {
         private GameObject toggleTemplate;
-        private BoolSettingsController templateController;
-        private Toggle templateControllerToggle;
 
         public override string[] Aliases => new[] { "toggle-setting", "bool-setting", "checkbox-setting", "checkbox" };
         public virtual string PrefabToggleName => "Fullscreen";
@@ -23,27 +22,25 @@ namespace BeatSaberMarkupLanguage.Tags
             if (toggleTemplate == null)
             {
                 toggleTemplate = Resources.FindObjectsOfTypeAll<Toggle>().Select(x => x.transform.parent.gameObject).First(p => p.name == PrefabToggleName);
-                templateController = toggleTemplate.GetComponent<BoolSettingsController>();
-                templateControllerToggle = templateController.GetComponentInChildren<Toggle>();
             }
 
-            templateController.enabled = false;
-            templateControllerToggle.isOn = false;
             GameObject gameObject = Object.Instantiate(toggleTemplate, parent, false);
             GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+            GameObject switchView = gameObject.transform.Find("SwitchView").gameObject;
             Object.Destroy(gameObject.GetComponent<BoolSettingsController>());
-            templateController.enabled = true;
-            templateControllerToggle.isOn = true;
 
             gameObject.name = "BSMLToggle";
             gameObject.SetActive(false);
 
             ToggleSetting toggleSetting = gameObject.AddComponent<ToggleSetting>();
+            AnimatedSwitchView animatedSwitchView = switchView.GetComponent<AnimatedSwitchView>();
 
-            toggleSetting.toggle = gameObject.GetComponentInChildren<Toggle>();
+            toggleSetting.toggle = switchView.GetComponent<Toggle>();
+            toggleSetting.toggle.onValueChanged.RemoveAllListeners();
+            toggleSetting.toggle.onValueChanged.AddListener(animatedSwitchView.HandleOnValueChanged);
             toggleSetting.toggle.interactable = true;
             toggleSetting.toggle.isOn = false;
-            toggleSetting.toggle.onValueChanged.RemoveAllListeners();
+            animatedSwitchView.enabled = true; // force refresh the UI state
 
             LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
 


### PR DESCRIPTION
BSML toggles sometimes get into this broken state:
![image](https://user-images.githubusercontent.com/1349975/117202960-7860d180-adbc-11eb-8796-b815e11ca03c.png)

The setting still works but there's no UI feedback. I'm able to consistently reproduce it by doing the following:
- Start the game.
- Go to *Options* > *Settings* and press *Cancel* without touching anything.
- Open a BSML-based menu that hasn't been parsed yet and uses a `<toggle-setting>` tag that is off (it may also need to **not** be using the `value` attribute).

I also noticed that the full screen issue was "fixed" by turning the toggle on after a copy is instantiated. This can, in some cases, force full screen on. The problem can be reproduced by doing the following:
- Start the game and make sure you're in windowed mode. If you're in full screen, turn it off through the game settings and **fully** restart the game.
- Go to *Options* > *Settings* and press *Cancel* without touching anything.
- Open any BSML-based UI that hasn't been parsed yet and uses the `<toggle-setting>` tag.
- Go back to *Options* > *Settings* (notice the *Fullscreen* toggle is now on) and press *Save*.
- The game does an internal restart and you are now in full screen.

I believe the issue that caused this whole problem in the first place is that `isOn` is being set to `false` before removing all the listeners on `onValueChanged`:

https://github.com/monkeymanboy/BeatSaberMarkupLanguage/blob/cee874e4a52504635530fe437f8336c42fbf7c2c/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs#L45-L46

Therefore, opening the *Settings* menu causes all the toggles created afterwards turn off full screen because `isOn` is still triggering the old listeners on `onValueChanged` (which are only registered when the *Fullscreen* toggle is first enabled, i.e. when the *Settings* menu is opened).

This PR fixes both of these issues.