### PR TITLE
1.16.3: Fix gameplay tabs / remove references to old multiplayer flows

### DIFF
--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
@@ -52,8 +52,6 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
                 case SinglePlayerLevelSelectionFlowCoordinator _:
                     menuType = MenuType.Solo;
                     break;
-                case HostGameServerLobbyFlowCoordinator _:
-                case QuickPlayLobbyFlowCoordinator _:
                 case GameServerLobbyFlowCoordinator _:
                     menuType = MenuType.Online;
                     break;


### PR DESCRIPTION
This PR fixes #91 for the Beat Saber 1.16.3 preview build.

In 1.16.3, there is only one flow coordinator for multiplayer lobbies, as there is no longer a distinction between player-hosted and quickplay. This simply removes the old references.