### PR TITLE
1.16.3: Fix privated members in HMUI

### DIFF
--- a/BeatSaberMarkupLanguage.sln
+++ b/BeatSaberMarkupLanguage.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29306.81

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollIndicator.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollIndicator.cs
@@ -12,8 +12,8 @@ namespace BeatSaberMarkupLanguage.Components
     {
         public RectTransform Handle
         {
-            get => _handle;
-            set => _handle = value;
+            get => Utilities.GetPrivateProperty<VerticalScrollIndicator, RectTransform>(this, "_handle");
+            set => Utilities.SetPrivateProperty(this, "_handle", value);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/Components/BSMLScrollableContainer.cs
+++ b/BeatSaberMarkupLanguage/Components/BSMLScrollableContainer.cs
@@ -10,31 +10,31 @@ namespace BeatSaberMarkupLanguage.Components
     {
         public Button PageUpButton
         {
-            get => _pageUpButton;
-            set => _pageUpButton = value;
+            get => Utilities.GetPrivateProperty<ScrollView, Button>(this, "_pageUpButton");
+            set => Utilities.SetPrivateProperty(this, "_pageUpButton", value);
         }
         public Button PageDownButton
         {
-            get => _pageDownButton;
-            set => _pageDownButton = value;
+            get => Utilities.GetPrivateProperty<ScrollView, Button>(this, "_pageDownButton");
+            set => Utilities.SetPrivateProperty(this, "_pageDownButton", value);
         }
 
         public RectTransform Viewport
         {
-            get => _viewport;
-            set => _viewport = value;
+            get => Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_viewport");
+            set => Utilities.SetPrivateProperty(this, "_viewport", value);
         }
 
         public RectTransform ContentRect
         {
-            get => _contentRectTransform;
-            set => _contentRectTransform = value;
+            get => Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_contentRectTransform");
+            set => Utilities.SetPrivateProperty(this, "_contentRectTransform", value);
         }
 
         public VerticalScrollIndicator ScrollIndicator
         {
-            get => _verticalScrollIndicator;
-            set => _verticalScrollIndicator = value;
+            get => Utilities.GetPrivateProperty<ScrollView, VerticalScrollIndicator>(this, "_verticalScrollIndicator");
+            set => Utilities.SetPrivateProperty(this, "_verticalScrollIndicator", value);
         }
 
         private bool alignBottom = false;
@@ -44,7 +44,7 @@ namespace BeatSaberMarkupLanguage.Components
             set
             {
                 alignBottom = value;
-                ScrollTo(_destinationPos, true);
+                ScrollTo(Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos"), true);
             }
         }
 
@@ -61,7 +61,7 @@ namespace BeatSaberMarkupLanguage.Components
         }
 
         private float contentHeight;
-        private float scrollPageHeight => _viewport.rect.height;
+        private float scrollPageHeight => Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_viewport").rect.height;
 
         private void UpdateViewportMask()
         {
@@ -72,7 +72,7 @@ namespace BeatSaberMarkupLanguage.Components
 
         public new void Awake()
         {
-            _buttonBinder = new ButtonBinder();
+            Utilities.SetPrivateProperty(this, "_buttonBinder", new ButtonBinder());
             
             RefreshContent();
             RefreshButtons();
@@ -81,6 +81,7 @@ namespace BeatSaberMarkupLanguage.Components
 
         public void RefreshBindings()
         {
+            ButtonBinder _buttonBinder = Utilities.GetPrivateProperty<ScrollView, ButtonBinder>(this, "_buttonBinder");
             if (_buttonBinder == null)
             {
                 return;
@@ -95,8 +96,8 @@ namespace BeatSaberMarkupLanguage.Components
 
         public void RefreshContent()
         {
-            SetContentSize(_contentRectTransform.rect.height);
-            contentHeight = _contentRectTransform.rect.height;
+            SetContentSize(Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_contentRectTransform").rect.height);
+            contentHeight = Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_contentRectTransform").rect.height;
             RefreshBindings();
             ComputeScrollFocusPosY();
         }
@@ -111,12 +112,14 @@ namespace BeatSaberMarkupLanguage.Components
         private bool runScrollAnim = false;
         public new void Update()
         {
+            RectTransform _contentRectTransform = Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_contentRectTransform");
             if (contentHeight != _contentRectTransform.rect.height && _contentRectTransform.rect.height > 0f)
                 ContentSizeUpdated();
 
             if (runScrollAnim)
             {
-                float num = Mathf.Lerp(_contentRectTransform.anchoredPosition.y, _destinationPos, Time.deltaTime * _smooth);
+                float _destinationPos = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos");
+                float num = Mathf.Lerp(_contentRectTransform.anchoredPosition.y, _destinationPos, Time.deltaTime * Utilities.GetPrivateProperty<ScrollView, float>(this, "_smooth"));
                 if (Mathf.Abs(num - _destinationPos) < 0.01f)
                 {
                     num = _destinationPos;
@@ -130,46 +133,46 @@ namespace BeatSaberMarkupLanguage.Components
         public new void RefreshButtons()
         {
             if (PageUpButton != null)
-                PageUpButton.interactable = _destinationPos > 0f;
+                PageUpButton.interactable = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") > 0f;
             if (PageDownButton != null)
-                PageDownButton.interactable = _destinationPos < contentHeight - (_viewport?.rect.height ?? 0);
+                PageDownButton.interactable = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") < contentHeight - (Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_viewport")?.rect.height ?? 0);
         }
 
         public new void ComputeScrollFocusPosY()
         {
             ItemForFocussedScrolling[] componentsInChildren = GetComponentsInChildren<ItemForFocussedScrolling>(true);
-            _scrollFocusPositions = (from item in componentsInChildren
-                                      select WorldPositionToScrollViewPosition(item.transform.position).y into i
+            Utilities.SetPrivateProperty(this, "_scrollFocusPositions", (from item in componentsInChildren
+                                      select ((Vector2)Utilities.InvokePrivateMethod(this, "WorldPositionToScrollViewPosition", new object[] {item.transform.position})).y into i
                                       orderby i
-                                      select i).ToArray<float>();
+                                      select i).ToArray<float>());
         }
 
         public new void UpdateVerticalScrollIndicator(float posY)
         {
-            if (_verticalScrollIndicator != null)
+            if (Utilities.GetPrivateProperty<ScrollView, VerticalScrollIndicator>(this, "_verticalScrollIndicator") != null)
             {
-                _verticalScrollIndicator.progress = posY / (contentHeight - _viewport.rect.height);
+                Utilities.GetPrivateProperty<ScrollView, VerticalScrollIndicator>(this, "_verticalScrollIndicator").progress = posY / (contentHeight - Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_viewport").rect.height);
             }
         }
 
         public new void ScrollDown(bool animated)
         {
-            float dstPosY = contentHeight - _viewport.rect.height;
+            float dstPosY = contentHeight - Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_viewport").rect.height;
             ScrollTo(dstPosY, animated);
         }
 
         public new void ScrollToWorldPosition(Vector3 worldPosition, float pageRelativePosition, bool animated)
         {
-            float num = WorldPositionToScrollViewPosition(worldPosition).y;
+            float num = ((Vector2)Utilities.InvokePrivateMethod(this, "WorldPositionToScrollViewPosition", new object[] {worldPosition})).y;
             num -= pageRelativePosition * scrollPageHeight;
             ScrollTo(num, animated);
         }
 
         public new void ScrollToWorldPositionIfOutsideArea(Vector3 worldPosition, float pageRelativePosition, float relativeBoundaryStart, float relativeBoundaryEnd, bool animated)
         {
-            float num = WorldPositionToScrollViewPosition(worldPosition).y;
-            float num2 = _destinationPos + relativeBoundaryStart * scrollPageHeight;
-            float num3 = _destinationPos + relativeBoundaryEnd * scrollPageHeight;
+            float num = ((Vector2)Utilities.InvokePrivateMethod(this, "WorldPositionToScrollViewPosition", new object[] {worldPosition})).y;
+            float num2 = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") + relativeBoundaryStart * scrollPageHeight;
+            float num3 = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") + relativeBoundaryEnd * scrollPageHeight;
             if (num > num2 && num < num3)
             {
                 return;
@@ -183,7 +186,7 @@ namespace BeatSaberMarkupLanguage.Components
             SetDestinationPosY(dstPosY);
             if (!animated)
             {
-                _contentRectTransform.anchoredPosition = new Vector2(0f, _destinationPos);
+                Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_contentRectTransform").anchoredPosition = new Vector2(0f, Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos"));
             }
             RefreshButtons();
             runScrollAnim = true;
@@ -191,22 +194,23 @@ namespace BeatSaberMarkupLanguage.Components
 
         public new void PageUpButtonPressed()
         {
-            float num = _destinationPos;
+            float num = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos");
             switch (_scrollType)
             {
                 case ScrollType.PageSize:
-                    num -= _pageStepNormalizedSize * scrollPageHeight;
+                    num -= Utilities.GetPrivateProperty<ScrollView, float>(this, "_pageStepNormalizedSize") * scrollPageHeight;
                     break;
-                case ScrollType.FixedCellSize:
+                case ScrollType.FixedCellSize: {
                     num -= _fixedCellSize * (float)(Mathf.RoundToInt(scrollPageHeight / _fixedCellSize) - 1);
                     num = (float)Mathf.FloorToInt(num / _fixedCellSize) * _fixedCellSize;
                     break;
+                }
                 case ScrollType.FocusItems:
                     {
-                        float threshold = _destinationPos + _scrollItemRelativeThresholdPosition * scrollPageHeight;
-                        num = (from posy in _scrollFocusPositions
+                        float threshold = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") + _scrollItemRelativeThresholdPosition * scrollPageHeight;
+                        num = (from posy in Utilities.GetPrivateProperty<ScrollView, float[]>(this, "_scrollFocusPositions")
                                where posy < threshold
-                               select posy).DefaultIfEmpty(_destinationPos).Max();
+                               select posy).DefaultIfEmpty(Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos")).Max();
                         num -= _pageStepNormalizedSize * scrollPageHeight;
                         break;
                     }
@@ -218,7 +222,7 @@ namespace BeatSaberMarkupLanguage.Components
 
         public new void PageDownButtonPressed()
         {
-            float num = _destinationPos;
+            float num = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos");
             switch (_scrollType)
             {
                 case ScrollType.PageSize:
@@ -230,10 +234,10 @@ namespace BeatSaberMarkupLanguage.Components
                     break;
                 case ScrollType.FocusItems:
                     {
-                        float threshold = _destinationPos + (1f - _scrollItemRelativeThresholdPosition) * scrollPageHeight;
-                        num = (from posy in _scrollFocusPositions
+                        float threshold = Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") + (1f - _scrollItemRelativeThresholdPosition) * scrollPageHeight;
+                        num = (from posy in Utilities.GetPrivateProperty<ScrollView, float[]>(this, "_scrollFocusPositions")
                                where posy > threshold
-                               select posy).DefaultIfEmpty(_destinationPos + scrollPageHeight).Min();
+                               select posy).DefaultIfEmpty(Utilities.GetPrivateProperty<ScrollView, float>(this, "_destinationPos") + scrollPageHeight).Min();
                         num -= (1f - _pageStepNormalizedSize) * scrollPageHeight;
                         break;
                     }
@@ -245,9 +249,9 @@ namespace BeatSaberMarkupLanguage.Components
 
         public new void SetDestinationPosY(float value)
         {
-            float maxPosition = contentHeight - _viewport.rect.height;
+            float maxPosition = contentHeight - Utilities.GetPrivateProperty<ScrollView, RectTransform>(this, "_viewport").rect.height;
             if (maxPosition < 0 && !AlignBottom) maxPosition = 0f;
-            _destinationPos = Mathf.Min(maxPosition, Mathf.Max(0f, value));
+            Utilities.SetPrivateProperty(this, "_destinationPos", Mathf.Min(maxPosition, Mathf.Max(0f, value)));
         }
     }
 }

--- a/BeatSaberMarkupLanguage/Components/ScrollViewContent.cs
+++ b/BeatSaberMarkupLanguage/Components/ScrollViewContent.cs
@@ -40,8 +40,8 @@ namespace BeatSaberMarkupLanguage.Components
         }
         private void UpdateScrollView()
         {
-            scrollView.SetContentSize((transform.GetChild(0) as RectTransform).rect.height);
-            scrollView.RefreshButtons();
+            Utilities.InvokePrivateMethod(scrollView, "SetContentSize", new object[] {(transform.GetChild(0) as RectTransform).rect.height});
+            Utilities.InvokePrivateMethod(scrollView, "RefreshButtons", null);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/Components/TextPageScrollViewRefresher.cs
+++ b/BeatSaberMarkupLanguage/Components/TextPageScrollViewRefresher.cs
@@ -11,13 +11,13 @@ namespace BeatSaberMarkupLanguage.Components
         void OnEnable()
         {
             scrollView?.SetText(scrollView.GetField<TextMeshProUGUI, TextPageScrollView>("_text").text);
-            scrollView?.RefreshButtons();
+            if (scrollView != null) Utilities.InvokePrivateMethod(scrollView, "RefreshButtons", null);
         }
 
         void OnRectTransformDimensionsChange()
         {
             scrollView?.SetText(scrollView.GetField<TextMeshProUGUI, TextPageScrollView>("_text").text);
-            scrollView?.RefreshButtons();
+            if (scrollView != null) Utilities.InvokePrivateMethod(scrollView, "RefreshButtons", null);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/Harmony Patches/ImageViewFilledImagePatch.cs
+++ b/BeatSaberMarkupLanguage/Harmony Patches/ImageViewFilledImagePatch.cs
@@ -9,7 +9,7 @@ using UnityEngine.UI;
 
 namespace BeatSaberMarkupLanguage.Harmony_Patches
 {
-    [HarmonyPatch(typeof(ImageView), nameof(ImageView.GenerateFilledSprite))]
+    [HarmonyPatch(typeof(ImageView), "GenerateFilledSprite")]
     internal static class ImageViewFilledImagePatch
     {
         // This is Beat Games' incorrect AddQuad method, which completely forgets about the curvedUIRadius parameter.

--- a/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/ToggleSettingTag.cs
@@ -37,7 +37,7 @@ namespace BeatSaberMarkupLanguage.Tags
 
             toggleSetting.toggle = switchView.GetComponent<Toggle>();
             toggleSetting.toggle.onValueChanged.RemoveAllListeners();
-            toggleSetting.toggle.onValueChanged.AddListener(animatedSwitchView.HandleOnValueChanged);
+            toggleSetting.toggle.onValueChanged.AddListener(Utilities.GetBindedPrivateAction<AnimatedSwitchView, bool>(animatedSwitchView, "HandleOnValueChanged"));
             toggleSetting.toggle.interactable = true;
             toggleSetting.toggle.isOn = false;
             animatedSwitchView.enabled = true; // force refresh the UI state

--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
@@ -91,13 +91,13 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             componentType.component.gameObject.GetComponent<LayoutElement>().preferredWidth = (componentType.component.gameObject.transform as RectTransform).sizeDelta.x;
 
             tableData.tableView.gameObject.SetActive(true);
-            tableData.tableView.LazyInit();
+            Utilities.InvokePrivateMethod(tableData.tableView, "LazyInit", null);
 
             if (componentType.data.TryGetValue("id", out string id))
             {
                 ScrollView scroller = tableData.tableView.GetField<ScrollView, TableView>("_scrollView");
-                parserParams.AddEvent(id + "#PageUp", scroller.PageUpButtonPressed);
-                parserParams.AddEvent(id + "#PageDown", scroller.PageDownButtonPressed);
+                parserParams.AddEvent(id + "#PageUp", Utilities.GetBindedPrivateAction(scroller, "PageUpButtonPressed"));
+                parserParams.AddEvent(id + "#PageDown", Utilities.GetBindedPrivateAction(scroller, "PageDownButtonPressed"));
             }
         }
     }

--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomListTableDataHandler.cs
@@ -93,13 +93,13 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             componentType.component.gameObject.GetComponent<LayoutElement>().preferredWidth = (componentType.component.gameObject.transform as RectTransform).sizeDelta.x;
 
             tableData.tableView.gameObject.SetActive(true);
-            tableData.tableView.LazyInit();
+            Utilities.InvokePrivateMethod(tableData.tableView, "LazyInit", null);
 
             if (componentType.data.TryGetValue("id", out string id))
             {
                 ScrollView scrollView = tableData.tableView.GetField<ScrollView, TableView>("_scrollView");
-                parserParams.AddEvent(id + "#PageUp", scrollView.PageUpButtonPressed);
-                parserParams.AddEvent(id + "#PageDown", scrollView.PageDownButtonPressed);
+                parserParams.AddEvent(id + "#PageUp", Utilities.GetBindedPrivateAction(scrollView, "PageUpButtonPressed"));
+                parserParams.AddEvent(id + "#PageDown", Utilities.GetBindedPrivateAction(scrollView, "PageDownButtonPressed"));
             }
         }
     }

--- a/BeatSaberMarkupLanguage/Utilities.cs
+++ b/BeatSaberMarkupLanguage/Utilities.cs
@@ -281,5 +281,25 @@ namespace BeatSaberMarkupLanguage
                 callback?.Invoke(www.downloadHandler.data);
             }
         }
+
+        public static U GetPrivateProperty<T, U>(T obj, string property) {
+            return (U)typeof(T).GetProperty(property, BindingFlags.NonPublic | BindingFlags.Instance).GetValue(obj);
+        }
+
+        public static void SetPrivateProperty<T, U>(T obj, string property, U value) {
+            typeof(T).GetProperty(property, BindingFlags.NonPublic | BindingFlags.Instance).SetValue(obj, value);
+        }
+
+        public static Action GetBindedPrivateAction<T>(T obj, string method) {
+            return () => typeof(T).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Instance).Invoke(obj, null);
+        }
+
+        public static UnityEngine.Events.UnityAction<A> GetBindedPrivateAction<T, A>(T obj, string method) {
+            return (A a) => typeof(T).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Instance).Invoke(obj, new object[] {a});
+        }
+
+        public static object InvokePrivateMethod<T>(T obj, string method, object[] args) {
+            return typeof(T).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Instance).Invoke(obj, args);
+        }
     }
 }

--- a/BeatSaberMarkupLanguage/manifest.json
+++ b/BeatSaberMarkupLanguage/manifest.json
@@ -11,7 +11,7 @@
   "name": "BeatSaberMarkupLanguage",
   "version": "1.5.4",
   "dependsOn": {
-    "BSIPA": "^4.1.6"
+    "BSIPA": "^4.2.0"
   },
   "links": {
     "project-home": "https://github.com/monkeymanboy/BeatSaberMarkupLanguage",


### PR DESCRIPTION
Beat Saber 1.16.3 ships a new version of HMUI that makes a number of members used by BSML private, which causes the plugin to no longer compile. This PR replaces references to those private members with reflection-based methods to maintain the same access to those members while working around the new access levels defined by HMUI.

This code might be a little bit dirty, as is sort of expected with reflection-based access, but I've tried to clean it up a little bit with some functions in `Utilities` to reduce duplication of code. A better option might be to remove any code that references those members, but I don't know enough about BSML's internals to know whether that's possible.

I also bumped BSIPA's minimum required version to 4.2.0 since that's the version 1.16.3 will be using.