### PR TITLE
Made FloatingScreen layer 5 (UI)

### DIFF
--- a/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
+++ b/BeatSaberMarkupLanguage/FloatingScreen/FloatingScreen.cs
@@ -124,6 +124,8 @@ namespace BeatSaberMarkupLanguage.FloatingScreen
             screen.ScreenSize = screenSize;
             screen.ShowHandle = createHandle;
 
+            screen.gameObject.layer = 5;
+
             return screen;
         }
 


### PR DESCRIPTION
Reason: FloatingScreens weren't hidden when UI was turned off in Cam2. Given other UI screens were layer 5 by default, made sense to do the same for FloatingScreen