### PR TITLE
Fixes for 1.18

### DIFF
--- a/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
+++ b/BeatSaberMarkupLanguage/BeatSaberMarkupLanguage.csproj
@@ -181,6 +181,7 @@
     <Compile Include="GameplaySetup\GameplaySetupMenu.cs" />
     <Compile Include="GameplaySetup\MenuType.cs" />
     <Compile Include="Harmony Patches\ImageViewFilledImagePatch.cs" />
+    <Compile Include="Harmony Patches\FixModalLayer.cs" />
     <Compile Include="Harmony Patches\ScrollViewGetPositionPatch.cs" />
     <Compile Include="Harmony Patches\SegmentedControlCellSelectionStateDidChange.cs" />
     <Compile Include="Logger.cs" />

--- a/BeatSaberMarkupLanguage/Harmony Patches/FixModalLayer.cs
+++ b/BeatSaberMarkupLanguage/Harmony Patches/FixModalLayer.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using HarmonyLib;
+using HMUI;
+using UnityEngine;
+
+namespace BeatSaberMarkupLanguage.Harmony_Patches {
+	[HarmonyPatch(typeof(ModalView), nameof(ModalView.Show))]
+	public static class FixModalBlockerLayer {
+		static void Postfix(ModalView __instance, GameObject ____blockerGO) {
+			var cb = ____blockerGO.GetComponent<Canvas>();
+
+			var h = (__instance.transform.parent.GetComponentInParent<HMUI.Screen>()
+				?.GetComponentsInChildren<Canvas>()
+				.Where(x => x.sortingLayerID == cb.sortingLayerID)
+				.Select(x => x.sortingOrder)
+				.DefaultIfEmpty(0)
+				.Max() ?? 0) + 1;
+
+			cb.overrideSorting = true;
+			cb.sortingOrder = h;
+
+			cb = __instance.GetComponent<Canvas>();
+			cb.overrideSorting = true;
+			cb.sortingOrder = h + 1;
+		}
+	}
+}


### PR DESCRIPTION
~~The code for the Box list is super hacky trash, but it (seems to) work and theres a total of like two plugins using box lists to begin with.~~

The modal changes are there to fix a (basegame?) issue found with the update - The level navigation controller has a higher sort order now, so modals in the solo view arent actually rendered in front of that. The harmony patch addresses that.