### PR TITLE
Added the option for sliders with buttons

### DIFF
--- a/BeatSaberMarkupLanguage/Components/Settings/GenericSliderSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/GenericSliderSetting.cs
@@ -1,6 +1,9 @@
 ﻿using HMUI;
+using IPA.Utilities;
+using System.Linq;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace BeatSaberMarkupLanguage.Components.Settings
 {
@@ -8,6 +11,9 @@ namespace BeatSaberMarkupLanguage.Components.Settings
     {
         public RangeValuesTextSlider slider;
         protected TextMeshProUGUI text;
+        public bool showButtons = false;
+        private static Sprite roundRect10; 
+
         public override bool interactable 
         { 
             get => slider?.interactable ?? false;
@@ -17,6 +23,20 @@ namespace BeatSaberMarkupLanguage.Components.Settings
                 {
                     slider.interactable = value;
                 }
+            }
+        }
+
+        public override void Setup()
+        {
+            if (!showButtons)
+            {
+                if (roundRect10 == null)
+                    roundRect10 = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "RoundRect10");
+
+                slider.image.sprite = roundRect10;
+                GameObject.Destroy(slider.GetField<Button, RangeValuesTextSlider>("_incButton").gameObject);
+                GameObject.Destroy(slider.GetField<Button, RangeValuesTextSlider>("_decButton").gameObject);
+                slider.transform.localPosition = new Vector3(slider.transform.localPosition.x + 7, 0, 0);
             }
         }
     }

--- a/BeatSaberMarkupLanguage/Components/Settings/GenericSliderSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/GenericSliderSetting.cs
@@ -36,7 +36,9 @@ namespace BeatSaberMarkupLanguage.Components.Settings
                 slider.image.sprite = roundRect10;
                 GameObject.Destroy(slider.GetField<Button, RangeValuesTextSlider>("_incButton").gameObject);
                 GameObject.Destroy(slider.GetField<Button, RangeValuesTextSlider>("_decButton").gameObject);
-                slider.transform.localPosition = new Vector3(slider.transform.localPosition.x + 7, 0, 0);
+                (slider.transform.Find("BG") as RectTransform).sizeDelta = new Vector2(0, 6);
+                (slider.transform as RectTransform).sizeDelta = new Vector2(38, 0);
+                (slider.transform.Find("SlidingArea") as RectTransform).sizeDelta = new Vector2(-4, -4);
             }
         }
     }

--- a/BeatSaberMarkupLanguage/Components/Settings/ListSliderSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/ListSliderSetting.cs
@@ -24,6 +24,7 @@ namespace BeatSaberMarkupLanguage.Components.Settings
 
         public override void Setup()
         {
+            base.Setup();
             slider.minValue = 0;
             slider.maxValue = values.Count() - 1;
             text = slider.GetComponentInChildren<TextMeshProUGUI>();

--- a/BeatSaberMarkupLanguage/Components/Settings/SliderSetting.cs
+++ b/BeatSaberMarkupLanguage/Components/Settings/SliderSetting.cs
@@ -23,6 +23,7 @@ namespace BeatSaberMarkupLanguage.Components.Settings
 
         public override void Setup()
         {
+            base.Setup();
             text = slider.GetComponentInChildren<TextMeshProUGUI>();
             slider.numberOfSteps = (int)Math.Round((slider.maxValue - slider.minValue) / increments) + 1;
             ReceiveValue();

--- a/BeatSaberMarkupLanguage/Tags/Settings/GenericSliderSettingTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/Settings/GenericSliderSettingTag.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using HMUI;
+using IPA.Utilities;
 using Polyglot;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,47 +13,42 @@ namespace BeatSaberMarkupLanguage.Tags.Settings
 {
     public abstract class GenericSliderSettingTag<T> : BSMLTag where T : GenericSliderSetting
     {
-        private FormattedFloatListSettingsValueController valueControllerTemplate;
-        private TimeSlider timeSliderTemplate;
+        private LayoutElement controllersTransformTemplate;
 
         public override GameObject CreateObject(Transform parent)
         {
-            if (valueControllerTemplate == null)
-                valueControllerTemplate = Resources.FindObjectsOfTypeAll<FormattedFloatListSettingsValueController>().First(x => x.name == "VRRenderingScale");
+            if (controllersTransformTemplate == null)
+                controllersTransformTemplate = Resources.FindObjectsOfTypeAll<LayoutElement>().First(x => x.name == "PositionX");
 
-            FormattedFloatListSettingsValueController baseSetting = Object.Instantiate(valueControllerTemplate, parent, false);
+            LayoutElement baseSetting = Object.Instantiate(controllersTransformTemplate, parent, false);
             baseSetting.name = "BSMLSliderSetting";
 
             GameObject gameObject = baseSetting.gameObject;
 
             T sliderSetting = gameObject.AddComponent<T>();
-            Object.Destroy(gameObject.transform.Find("ValuePicker").gameObject);
 
-            if (timeSliderTemplate == null)
-                timeSliderTemplate = Resources.FindObjectsOfTypeAll<TimeSlider>().First(s => s.name == "RangeValuesTextSlider" && s.transform.parent?.name == "SongStart");
-
-            sliderSetting.slider = Object.Instantiate(timeSliderTemplate, gameObject.transform, false);
+            sliderSetting.slider = baseSetting.GetComponentInChildren<CustomFormatRangeValuesSlider>();
             sliderSetting.slider.name = "BSMLSlider";
             sliderSetting.slider.GetComponentInChildren<TextMeshProUGUI>().enableWordWrapping = false;
+            (sliderSetting.slider as TextSlider).SetField("_enableDragging", true);
             (sliderSetting.slider.transform as RectTransform).anchorMin = new Vector2(1, 0);
             (sliderSetting.slider.transform as RectTransform).anchorMax = new Vector2(1, 1);
-            (sliderSetting.slider.transform as RectTransform).sizeDelta = new Vector2(40, 0);
+            (sliderSetting.slider.transform as RectTransform).sizeDelta = new Vector2(52, 0);
             (sliderSetting.slider.transform as RectTransform).pivot = new Vector2(1, 0.5f);
             (sliderSetting.slider.transform as RectTransform).anchoredPosition = new Vector2(0, 0);
 
-            Object.Destroy(baseSetting);
-
-            GameObject nameText = gameObject.transform.Find("NameText").gameObject;
+            GameObject nameText = gameObject.transform.Find("Title").gameObject;
             LocalizedTextMeshProUGUI localizedText = ConfigureLocalizedText(nameText);
 
             TextMeshProUGUI text = nameText.GetComponent<TextMeshProUGUI>();
             text.text = "Default Text";
+            text.rectTransform.anchorMax = Vector2.one;
 
             List<Component> externalComponents = gameObject.AddComponent<ExternalComponents>().components;
             externalComponents.Add(text);
             externalComponents.Add(localizedText);
 
-            gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
+            baseSetting.preferredWidth = 90;
 
             gameObject.SetActive(true);
             return gameObject;

--- a/BeatSaberMarkupLanguage/TypeHandlers/Settings/ListSliderSettingHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/Settings/ListSliderSettingHandler.cs
@@ -12,7 +12,8 @@ namespace BeatSaberMarkupLanguage.TypeHandlers.Settings
     {
         public override Dictionary<string, string[]> Props => new Dictionary<string, string[]>()
         {
-            { "options", new[]{ "options", "choices" } }
+            { "options", new[]{ "options", "choices" } },
+            { "showButtons", new[] { "show-buttons" } }
         };
 
         public override void HandleType(ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -30,6 +31,9 @@ namespace BeatSaberMarkupLanguage.TypeHandlers.Settings
             {
                 throw new Exception("list must have associated options");
             }
+
+            if (componentType.data.TryGetValue("showButtons", out string showButtons))
+                listSetting.showButtons = Parse.Bool(showButtons);
         }
     }
 }

--- a/BeatSaberMarkupLanguage/TypeHandlers/Settings/SliderSettingHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/Settings/SliderSettingHandler.cs
@@ -15,7 +15,8 @@ namespace BeatSaberMarkupLanguage.TypeHandlers.Settings
             { "increment", new[] { "increment" } },
             { "minValue", new[] { "min" } },
             { "maxValue", new[] { "max" } },
-            { "isInt", new[] { "integer-only" } }
+            { "isInt", new[] { "integer-only" } },
+            { "showButtons", new[] { "show-buttons" } }
         };
 
         public override void HandleType(ComponentTypeWithData componentType, BSMLParserParams parserParams)
@@ -33,6 +34,9 @@ namespace BeatSaberMarkupLanguage.TypeHandlers.Settings
 
             if (componentType.data.TryGetValue("maxValue", out string maxValue))
                 sliderSetting.slider.maxValue = Parse.Float(maxValue);
+
+            if (componentType.data.TryGetValue("showButtons", out string showButtons))
+                sliderSetting.showButtons = Parse.Bool(showButtons);
         }
     }
 }


### PR DESCRIPTION
Changes to SliderSetting and ListSliderSetting: The slider we used for cloning is now replaced with the controller settings slider instead (requiring less things to clone as a result too to get the text). The slider buttons are also cloned: so sliders could be precisely changed with buttons on either end. To enable it, "show-buttons" needs to be set to true.