### PR TITLE
Added the option to dynamically remove a gameplay setup tab

### DIFF
--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using IPA.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -11,6 +12,8 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
 {
     public class GameplaySetup : PersistentSingleton<GameplaySetup>
     {
+        public event Action TabsCreatedEvent;
+
         private static readonly FieldAccessor<LayoutGroup, List<RectTransform>>.Accessor LayoutGroupChildren = FieldAccessor<LayoutGroup, List<RectTransform>>.GetAccessor("m_RectChildren");
         private GameplaySetupViewController gameplaySetupViewController;
         private LayoutGroup layoutGroup;
@@ -71,6 +74,8 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
             }
             foreach (GameplaySetupMenu menu in menus)
                 menu.SetVisible(menu.IsMenuType(menuType));
+
+            TabsCreatedEvent?.Invoke();
         }
 
         private void GameplaySetupDidDeactivate(bool removedFromHierarchy, bool screenSystemDisabling)

--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
@@ -1,9 +1,9 @@
 ﻿using BeatSaberMarkupLanguage.Attributes;
+using BeatSaberMarkupLanguage.Components;
 using IPA.Utilities;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -14,6 +14,15 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
         private static readonly FieldAccessor<LayoutGroup, List<RectTransform>>.Accessor LayoutGroupChildren = FieldAccessor<LayoutGroup, List<RectTransform>>.GetAccessor("m_RectChildren");
         private GameplaySetupViewController gameplaySetupViewController;
         private LayoutGroup layoutGroup;
+
+        [UIComponent("new-tab-selector")]
+        private TabSelector tabSelector;
+
+        [UIComponent("vanilla-tab")]
+        private Transform vanillaTab;
+
+        [UIComponent("mods-tab")]
+        private Transform modsTab;
 
         [UIValue("vanilla-items")]
         private List<Transform> vanillaItems = new List<Transform>();
@@ -37,6 +46,7 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
             BSMLParser.instance.Parse(Utilities.GetResourceContent(Assembly.GetExecutingAssembly(), "BeatSaberMarkupLanguage.Views.gameplay-setup.bsml"), gameplaySetupViewController.gameObject, this);
             
             gameplaySetupViewController.didActivateEvent += GameplaySetupDidActivate;
+            gameplaySetupViewController.didDeactivateEvent += GameplaySetupDidDeactivate;
         }
 
         private void GameplaySetupDidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling)
@@ -61,6 +71,13 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
             }
             foreach (GameplaySetupMenu menu in menus)
                 menu.SetVisible(menu.IsMenuType(menuType));
+        }
+
+        private void GameplaySetupDidDeactivate(bool removedFromHierarchy, bool screenSystemDisabling)
+        {
+            tabSelector.textSegmentedControl.SelectCellWithNumber(0);
+            vanillaTab.gameObject.SetActive(true);
+            modsTab.gameObject.SetActive(false);
         }
 
         public void AddTab(string name, string resource, object host)

--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
@@ -97,6 +97,14 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
             menus.Add(new GameplaySetupMenu(name, resource, host, assembly, menuType));
         }
 
+        /// <summary>Allows tab to dynamically disappear and reappear</summary>
+        public void SetTabVisibility(string name, bool isVisible)
+        {
+            IEnumerable<GameplaySetupMenu> menu = menus.OfType<GameplaySetupMenu>().Where(x => x.name == name);
+            if (menu.Count() > 0)
+                menu.FirstOrDefault().SetVisible(isVisible);
+        }
+
         /// <summary>Warning, for now it will not be removed until fresh menu scene reload</summary>
         public void RemoveTab(string name)
         {

--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetup.cs
@@ -105,6 +105,9 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
         /// <summary>Allows tab to dynamically disappear and reappear</summary>
         public void SetTabVisibility(string name, bool isVisible)
         {
+            if (!gameplaySetupViewController.isActiveAndEnabled)
+                return;
+
             IEnumerable<GameplaySetupMenu> menu = menus.OfType<GameplaySetupMenu>().Where(x => x.name == name);
             if (menu.Count() > 0)
                 menu.FirstOrDefault().SetVisible(isVisible);

--- a/BeatSaberMarkupLanguage/GameplaySetup/MenuType.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/MenuType.cs
@@ -5,6 +5,7 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
     [Flags]
     public enum MenuType
     {
+        None = 0,
         Solo = 1,
         Online = 2,
         Campaign = 4,

--- a/BeatSaberMarkupLanguage/Views/gameplay-setup.bsml
+++ b/BeatSaberMarkupLanguage/Views/gameplay-setup.bsml
@@ -1,9 +1,9 @@
 ﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
-  <tab-selector tab-tag='new-tab' anchor-pos-y='0' size-delta-y='6' size-delta-x='-20' child-expand-width='true' child-control-width='true' has-separator='false'/>
-  <tab tags='new-tab' tab-name='Vanilla' anchor-pos-y='-8'>
+  <tab-selector id='new-tab-selector' tab-tag='new-tab' anchor-pos-y='0' size-delta-y='6' size-delta-x='-20' child-expand-width='true' child-control-width='true' has-separator='false'/>
+  <tab id='vanilla-tab' tags='new-tab' tab-name='Vanilla' anchor-pos-y='-8'>
     <macro.reparent transforms='vanilla-items'/>
   </tab>
-  <tab tags='new-tab' tab-name='Mods'>
+  <tab id='mods-tab' tags='new-tab' tab-name='Mods'>
     <horizontal child-expand-width='false' pref-height='6' anchor-pos-y='28' size-delta-x='-16'>
       <page-button direction='Left' pref-width='6' pref-height='6' tags='left-button'/>
       <tab-selector tab-tag='mod-tab' child-expand-width='true' child-control-width='true' has-separator='false' page-count='3' left-button-tag='left-button' right-button-tag='right-button'/>


### PR DESCRIPTION
This will be used by both PlaylistManager and Nya in a future update. Also fixes a bug where a null ref exception occurs if a gameplay setup tab is opened in multiplayer/campaigns before opening the solo menu.