### PR TITLE
Don't suppress list type

### DIFF
--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
@@ -73,7 +73,13 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             {
                 if (!parserParams.values.TryGetValue(value, out BSMLValue contents))
                     throw new Exception("value '" + value + "' not found");
-                tableData.data = contents.GetValue() as List<object>;
+
+                var tableDataValue = contents.GetValue();
+                if (tableDataValue is not List<object> tableDataList) {
+                    throw new Exception($"Value '{value}' is not a List<object>, which is required for custom-list");
+                }
+
+                tableData.data = tableDataList;
                 tableData.tableView.ReloadData();
             }
 

--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomCellListTableDataHandler.cs
@@ -75,7 +75,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
                     throw new Exception("value '" + value + "' not found");
 
                 var tableDataValue = contents.GetValue();
-                if (tableDataValue is not List<object> tableDataList) {
+                if (!(tableDataValue is List<object> tableDataList)) {
                     throw new Exception($"Value '{value}' is not a List<object>, which is required for custom-list");
                 }
 

--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomListTableDataHandler.cs
@@ -75,7 +75,14 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             {
                 if (!parserParams.values.TryGetValue(value, out BSMLValue contents))
                     throw new Exception("value '" + value + "' not found");
-                tableData.data = contents.GetValue() as List<CustomCellInfo>;
+
+
+                var tableDataValue = contents.GetValue();
+                if (tableDataValue is not List<CustomCellInfo> tableDataList) {
+                    throw new Exception($"Value '{value}' is not a List<CustomCellInfo>, which is required for custom-list");
+                }
+
+                tableData.data = tableDataList;
                 tableData.tableView.ReloadData();
             }
 

--- a/BeatSaberMarkupLanguage/TypeHandlers/CustomListTableDataHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/CustomListTableDataHandler.cs
@@ -78,7 +78,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
 
 
                 var tableDataValue = contents.GetValue();
-                if (tableDataValue is not List<CustomCellInfo> tableDataList) {
+                if (!(tableDataValue is List<CustomCellInfo> tableDataList)) {
                     throw new Exception($"Value '{value}' is not a List<CustomCellInfo>, which is required for custom-list");
                 }
 


### PR DESCRIPTION
This bug has existed for far too long (yes, it's a bug)

Too many times have I seen the effect of this code cause even the sanest of sane to go, well insane. The problem is simple: if the field type is not `List<object>`, `as List<object>` will assign the data as null and therefore ignore the unintended consequence of not having the proper field type.

Not anymore! Exception will now be thrown if the list type is wrong, however the wording could improve.