### PR TITLE
Added an option to hide GameplaySetup tabs

### DIFF
--- a/BeatSaberMarkupLanguage/Config.cs
+++ b/BeatSaberMarkupLanguage/Config.cs
@@ -8,5 +8,8 @@ namespace BeatSaberMarkupLanguage
     {
         [NonNullable, UseConverter(typeof(ListConverter<string>))]
         public virtual List<string> PinnedMods { get; set; } = new List<string>();
+
+        [NonNullable, UseConverter(typeof(ListConverter<string>))]
+        public virtual List<string> HiddenTabs { get; set; } = new List<string>();
     }
 }

--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetupCell.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetupCell.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel;
+using BeatSaberMarkupLanguage.Attributes;
+using HMUI;
+
+namespace BeatSaberMarkupLanguage.GameplaySetup
+{
+    internal class GameplaySetupCell : TableCell, INotifyPropertyChanged
+    {
+        private GameplaySetupMenu tab;
+
+        [UIValue("tab-name")]
+        private string Name => tab?.name;
+
+        [UIValue("tab-visible")]
+        private bool Visible
+        {
+            get => tab != null && tab.visible;
+            set
+            {
+                if (tab != null)
+                {
+                    tab.visible = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Visible)));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public GameplaySetupCell PopulateCell(GameplaySetupMenu tab)
+        {
+            this.tab = tab;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Visible)));
+            return this;
+        }
+    }
+}

--- a/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetupMenu.cs
+++ b/BeatSaberMarkupLanguage/GameplaySetup/GameplaySetupMenu.cs
@@ -23,6 +23,22 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
         [UIComponent("root-tab")]
         private Tab tab;
 
+        public bool visible
+        {
+            get => !Plugin.config.HiddenTabs.Contains(name);
+            set
+            {
+                if (value)
+                {
+                    Plugin.config.HiddenTabs.Remove(name);
+                }
+                else if (visible)
+                {
+                    Plugin.config.HiddenTabs.Add(name);
+                }
+            }
+        }
+
         public GameplaySetupMenu(string name, string resource, object host, Assembly assembly, MenuType menuType)
         {
             this.name = name;
@@ -56,7 +72,7 @@ namespace BeatSaberMarkupLanguage.GameplaySetup
 
         public void SetVisible(bool isVisible)
         {
-            tab.IsVisible = isVisible;
+            tab.IsVisible = visible && isVisible;
         }
 
         public bool IsMenuType(MenuType toCheck)

--- a/BeatSaberMarkupLanguage/Views/gameplay-setup-cell.bsml
+++ b/BeatSaberMarkupLanguage/Views/gameplay-setup-cell.bsml
@@ -1,0 +1,3 @@
+﻿<horizontal vertical-fit='PreferredSize' pref-height='8' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
+	<checkbox-setting text='~tab-name' value='tab-visible' bind-value='true' apply-on-change='true' />
+</horizontal>

--- a/BeatSaberMarkupLanguage/Views/gameplay-setup.bsml
+++ b/BeatSaberMarkupLanguage/Views/gameplay-setup.bsml
@@ -8,9 +8,15 @@
       <page-button direction='Left' pref-width='6' pref-height='6' tags='left-button'/>
       <tab-selector tab-tag='mod-tab' child-expand-width='true' child-control-width='true' has-separator='false' page-count='3' left-button-tag='left-button' right-button-tag='right-button'/>
       <page-button direction='Right' pref-width='6' pref-height='6' tags='right-button'/>
+	  <clickable-text text='👁' hover-hint='Show/Hide Tabs' on-click='show-modal' />
     </horizontal>
     <macro.for-each items='mod-menus' pass-back-tags='true'>
       <tab tags='mod-tab' tab-name='~tab-name' id='root-tab' anchor-max-y='0.75'/>
     </macro.for-each>
+	<modal id='list-modal' clickerino-offerino-closerino='true' size-delta-x='65' size-delta-y='35'>
+	  <horizontal anchor-pos-x='-2' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
+	    <list id='mods-list' show-scrollbar='true' stick-scrolling='true' pref-width='55' pref-height='32' />
+	  </horizontal>
+	</modal>
   </tab>
 </bg>

--- a/BeatSaberMarkupLanguage/Views/gameplay-setup.bsml
+++ b/BeatSaberMarkupLanguage/Views/gameplay-setup.bsml
@@ -8,14 +8,15 @@
       <page-button direction='Left' pref-width='6' pref-height='6' tags='left-button'/>
       <tab-selector tab-tag='mod-tab' child-expand-width='true' child-control-width='true' has-separator='false' page-count='3' left-button-tag='left-button' right-button-tag='right-button'/>
       <page-button direction='Right' pref-width='6' pref-height='6' tags='right-button'/>
-	  <clickable-text text='👁' hover-hint='Show/Hide Tabs' on-click='show-modal' />
     </horizontal>
+	<clickable-text text='👁' hover-hint='Show/Hide Tabs' on-click='show-modal' anchor-pos-x='97' anchor-pos-y='28' />
     <macro.for-each items='mod-menus' pass-back-tags='true'>
       <tab tags='mod-tab' tab-name='~tab-name' id='root-tab' anchor-max-y='0.75'/>
     </macro.for-each>
 	<modal id='list-modal' clickerino-offerino-closerino='true' size-delta-x='65' size-delta-y='35'>
+	  <loading-indicator active='~is-loading' preserve-aspect='true' pref-width='20' pref-height='20' />
 	  <horizontal anchor-pos-x='-2' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
-	    <list id='mods-list' show-scrollbar='true' stick-scrolling='true' pref-width='55' pref-height='32' />
+	    <list id='mods-list' active='~loaded' show-scrollbar='true' stick-scrolling='true' size-delta-y='32' pref-width='55' pref-height='32' />
 	  </horizontal>
 	</modal>
   </tab>


### PR DESCRIPTION
Added a button that shows a list of mod tabs in GameplaySetup and toggles to show/hide each. This allows users to declutter their GameplaySetup menu since a lot of mods are adding UI there and it makes it hard to navigate around to most used mods.