### PR TITLE
Fix missing text on mod menu buttons when returning from editor

### DIFF
--- a/BeatSaberMarkupLanguage/Tags/BSMLTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/BSMLTag.cs
@@ -40,6 +40,7 @@ namespace BeatSaberMarkupLanguage.Tags
 
             localizedText.enabled = false;
             localizedText.Key = string.Empty;
+            Localization.Instance.RemoveOnLocalizeEvent(localizedText);
 
             return localizedText;
         }

--- a/BeatSaberMarkupLanguage/manifest.json
+++ b/BeatSaberMarkupLanguage/manifest.json
@@ -8,8 +8,8 @@
     "An XML based UI system."
   ],
   "author": "monkeymanboy",
-  "gameVersion": "1.19.0",
-  "version": "1.6.3",
+  "gameVersion": "1.22.1",
+  "version": "1.6.5",
   "dependsOn": {
     "BSIPA": "^4.2.0"
   },


### PR DESCRIPTION
This should fix this issue when going back from the editor:

![image](https://user-images.githubusercontent.com/793322/169669469-04c6b47c-8cc3-41df-941d-7ec52ff545ca.png)

This issue persists until an internal restart and only happens on localized clients.