### PR TITLE
Fix more broken stuff when returning from editor

### DIFF
--- a/BeatSaberMarkupLanguage/Settings/UI/ModSettingsFlowCoordinator.cs
+++ b/BeatSaberMarkupLanguage/Settings/UI/ModSettingsFlowCoordinator.cs
@@ -85,7 +85,7 @@ namespace BeatSaberMarkupLanguage.Settings
         private void Ok()
         {
             EmitEventToAll("apply");
-            Resources.FindObjectsOfTypeAll<MenuTransitionsHelper>().First().RestartGame();
+            FindObjectOfType<MenuTransitionsHelper>().RestartGame();
         }
 
         [UIAction("cancel-click")]

--- a/BeatSaberMarkupLanguage/Tags/LoadingIndicatorTag.cs
+++ b/BeatSaberMarkupLanguage/Tags/LoadingIndicatorTag.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using HMUI;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -13,7 +14,7 @@ namespace BeatSaberMarkupLanguage.Tags
         public override GameObject CreateObject(Transform parent)
         {
             if (loadingTemplate == null)
-                loadingTemplate = Resources.FindObjectsOfTypeAll<GameObject>().Where(x => x.name == "LoadingIndicator").First();
+                loadingTemplate = Resources.FindObjectsOfTypeAll<ImageView>().Where(x => x.gameObject.name == "LoadingIndicator").First().gameObject;
             GameObject loadingIndicator = Object.Instantiate(loadingTemplate, parent, false);
             loadingIndicator.name = "BSMLLoadingIndicator";
 

--- a/BeatSaberMarkupLanguage/manifest.json
+++ b/BeatSaberMarkupLanguage/manifest.json
@@ -9,7 +9,7 @@
   ],
   "author": "monkeymanboy",
   "gameVersion": "1.22.1",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "dependsOn": {
     "BSIPA": "^4.2.0"
   },


### PR DESCRIPTION
This PR addresses those issues:
- The editor is instantiating a new `MenuTransitionHelper`, which becomes inactive after returning back to the main menu, and its reference to the `GameScenesManager` is then null, so it throws.
- BSML also gets a loading indicator from the editor that doesn't have an `ImageView`, breaking mods depending on it.