### PR TITLE
Add no mod buttons message and vertical animation for mod settings

### DIFF
--- a/BeatSaberMarkupLanguage/Settings/BSMLSettings.cs
+++ b/BeatSaberMarkupLanguage/Settings/BSMLSettings.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using HMUI;
 using UnityEngine;
 using UnityEngine.UI;
 using static BeatSaberMarkupLanguage.Components.CustomListTableData;
@@ -106,7 +107,7 @@ namespace BeatSaberMarkupLanguage.Settings
             BeatSaberUI.MainFlowCoordinator.PresentFlowCoordinator(flowCoordinator, new Action(delegate{
                 flowCoordinator.ShowInitial();
                 flowCoordinator.isAnimating = false;
-            }));
+            }), ViewController.AnimationDirection.Vertical);
         }
 
     }

--- a/BeatSaberMarkupLanguage/Settings/UI/ModSettingsFlowCoordinator.cs
+++ b/BeatSaberMarkupLanguage/Settings/UI/ModSettingsFlowCoordinator.cs
@@ -92,7 +92,7 @@ namespace BeatSaberMarkupLanguage.Settings
         private void Cancel()
         {
             if (isPresenting || isAnimating) return;
-            BeatSaberUI.MainFlowCoordinator.DismissFlowCoordinator(this);
+            BeatSaberUI.MainFlowCoordinator.DismissFlowCoordinator(this, null, ViewController.AnimationDirection.Vertical);
             EmitEventToAll("cancel");
         }
 

--- a/BeatSaberMarkupLanguage/Views/main-left-screen.bsml
+++ b/BeatSaberMarkupLanguage/Views/main-left-screen.bsml
@@ -1,17 +1,22 @@
 <bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd' id='root-object' size-delta-x='-50' anchor-pos-x='-10'>
-  <macro.if value='any-buttons'>
-    <vertical pref-width='145' vertical-fit='PreferredSize' preferred-height='80' spacing='4'>
-      <horizontal bg='panel-top' pad-left='10' pad-right='10' horizontal-fit='PreferredSize'>
-        <text text='Mods' align='Center' font-size='10'></text>
+  <vertical child-control-height='false'>
+    <horizontal bg='panel-top' pad-left='10' pad-right='10' horizontal-fit='PreferredSize'>
+      <text text='Mods' align='Center' font-size='10'></text>
+    </horizontal>
+    <macro.if value='any-buttons'>
+      <horizontal>
+        <scroll-view horizontal-fit='PreferredSize' vertical-fit='PreferredSize' pref-width='143' pref-height='59' child-control-height='true' child-control-width='false'>
+          <grid horizontal-fit='Unconstrained' size-delta-x='124' cell-size-y='9' cell-size-x='40' spacing-x='2' spacing-y='2' align='Center'>
+            <macro.for-each items='buttons'>
+              <button id='menu-button' pref-width='40' pref-height='9' text='~text' hover-hint='~hover-hint' interactable='~interactable' on-click='button-click' pad='0'></button>
+            </macro.for-each>
+          </grid>
+        </scroll-view>
       </horizontal>
-      <scroll-view horizontal-fit='PreferredSize' vertical-fit='PreferredSize' preferred-height='57' child-control-height='true' child-control-width='false'>
-        <grid horizontal-fit='Unconstrained' size-delta-x='126' cell-size-y='9' cell-size-x='40' spacing-x='2' spacing-y='2' align='Center'>
-	        <macro.for-each items='buttons'>
-		        <button id='menu-button' pref-width='40' pref-height='9' text='~text' hover-hint='~hover-hint' interactable='~interactable' on-click='button-click' pad='0'></button>
-	        </macro.for-each>
-        </grid>
-      </scroll-view>
-    </vertical>
+    </macro.if>
+  </vertical>
+  <macro.if value='!any-buttons'>
+    <text anchor-pos-y='6' size-delta-x='82' text='None of your currently installed mods add any buttons to this part of the menu!' font-align='Center' font-size='5'/>
   </macro.if>
   <!--<modal show-event='show-pins' hide-event='close-modals' size-delta-x='35' size-delta-y='65' click-off-closes='true'>
     <vertical>


### PR DESCRIPTION
What this PR does:

- Changes the default animation of mod settings to Vertical to be consistent with the other settings panels.
- People often think that they are unmodded when there's no mod button in this menu (missing "More Songs" button). So we add a message to inform them.

![image](https://user-images.githubusercontent.com/793322/169952981-e53ddc87-f20c-48bd-a63a-ab8eb42dee9a.png)