### PR TITLE
Make all internals visible to BSML.BeatmapEditor

### DIFF
--- a/BeatSaberMarkupLanguage/Plugin.cs
+++ b/BeatSaberMarkupLanguage/Plugin.cs
@@ -19,7 +19,9 @@ using IPA.Config.Stores;
 using System.IO;
 using Zenject;
 using HMUI;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("BSML.BeatmapEditor", AllInternalsVisible = true)]
 namespace BeatSaberMarkupLanguage
 {
     [Plugin(RuntimeOptions.SingleStartInit)]


### PR DESCRIPTION
Supersedes #134, this PR simply exposes all internals of BSML to my upcoming BSML.BeatmapEditor library (BSML shenanigans for the official editor) due to how much editor UI changes in nature very quickly rather than keeping it in the main BSML project, so I can release fixes/updates very quickly for BSML.BeatmapEditor.