### PR TITLE
Hide new promo background/text by default

### DIFF
--- a/BeatSaberMarkupLanguage/Components/CustomListTableData.cs
+++ b/BeatSaberMarkupLanguage/Components/CustomListTableData.cs
@@ -131,6 +131,10 @@ namespace BeatSaberMarkupLanguage.Components
                     TextMeshProUGUI authorText = tableCell.GetField<TextMeshProUGUI, LevelListTableCell>("_songAuthorText");
                     tableCell.GetField<TextMeshProUGUI, LevelListTableCell>("_songBpmText").gameObject.SetActive(false);
                     tableCell.GetField<TextMeshProUGUI, LevelListTableCell>("_songDurationText").gameObject.SetActive(false);
+                    tableCell.GetField<GameObject, LevelListTableCell>("_promoBackgroundGo").SetActive(false);
+                    tableCell.GetField<GameObject, LevelListTableCell>("_promoBadgeGo").SetActive(false);
+                    tableCell.GetField<GameObject, LevelListTableCell>("_updatedBadgeGo").SetActive(false);
+                    tableCell.GetField<LayoutWidthLimiter, LevelListTableCell>("_layoutWidthLimiter").limitWidth = false;
                     tableCell.GetField<Image, LevelListTableCell>("_favoritesBadgeImage").gameObject.SetActive(false);
                     tableCell.transform.Find("BpmIcon").gameObject.SetActive(false);
                     if (expandCell)


### PR DESCRIPTION
This just disables the promo background and badges, and fixes the name text being cut off. I'm not sure what `expandCell`'s expected behaviour is so I left it as-is but if it's supposed to resize the text to the cell width, I'd be happy to fix that as well (it currently overflows).

Before:
![image](https://user-images.githubusercontent.com/1349975/222154820-fece27a7-d9bd-47fa-b70e-d0155f3e5d97.png)


After:
![image](https://user-images.githubusercontent.com/1349975/222154418-9ac6cb75-ef53-4ab5-80e1-f40a45e0fd7a.png)