### PR TITLE
Bump version

### DIFF
--- a/BeatSaberMarkupLanguage/manifest.json
+++ b/BeatSaberMarkupLanguage/manifest.json
@@ -8,8 +8,8 @@
     "An XML based UI system."
   ],
   "author": "monkeymanboy",
-  "gameVersion": "1.22.1",
-  "version": "1.6.7",
+  "gameVersion": "1.28.0",
+  "version": "1.6.9",
   "dependsOn": {
     "BSIPA": "^4.2.0"
   },


### PR DESCRIPTION
Bumps (game)version for beatmods.
.9 patch version as .8 is currently used, but was apparently never committed. 