### PR TITLE
fix for game 1.29.0

### DIFF
--- a/BeatSaberMarkupLanguage/Components/CustomListTableData.cs
+++ b/BeatSaberMarkupLanguage/Components/CustomListTableData.cs
@@ -131,10 +131,8 @@ namespace BeatSaberMarkupLanguage.Components
                     TextMeshProUGUI authorText = tableCell.GetField<TextMeshProUGUI, LevelListTableCell>("_songAuthorText");
                     tableCell.GetField<TextMeshProUGUI, LevelListTableCell>("_songBpmText").gameObject.SetActive(false);
                     tableCell.GetField<TextMeshProUGUI, LevelListTableCell>("_songDurationText").gameObject.SetActive(false);
-                    tableCell.GetField<GameObject, LevelListTableCell>("_promoBackgroundGo").SetActive(false);
                     tableCell.GetField<GameObject, LevelListTableCell>("_promoBadgeGo").SetActive(false);
                     tableCell.GetField<GameObject, LevelListTableCell>("_updatedBadgeGo").SetActive(false);
-                    tableCell.GetField<LayoutWidthLimiter, LevelListTableCell>("_layoutWidthLimiter").limitWidth = false;
                     tableCell.GetField<Image, LevelListTableCell>("_favoritesBadgeImage").gameObject.SetActive(false);
                     tableCell.transform.Find("BpmIcon").gameObject.SetActive(false);
                     if (expandCell)

--- a/BeatSaberMarkupLanguage/manifest.json
+++ b/BeatSaberMarkupLanguage/manifest.json
@@ -8,8 +8,8 @@
     "An XML based UI system."
   ],
   "author": "monkeymanboy",
-  "gameVersion": "1.28.0",
-  "version": "1.6.9",
+  "gameVersion": "1.29.0",
+  "version": "1.6.10",
   "dependsOn": {
     "BSIPA": "^4.2.0"
   },


### PR DESCRIPTION
They moved the promotion badges to be over the song cover. They also removed the colourful promotion background and the layout limiter.

This is the only place where bsml broke as much as I'm aware. I did do some amount of UI testing with all the other mods I'm using but it may not be exhaustive. 