### PR TITLE
Add NuGet.Config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         path: ${{ runner.temp }}\BeatSaberBindings
 
     - name: Add NuGet source
-      run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text "https://nuget.pkg.github.com/nicoco007/index.json"
+      run: dotnet nuget update source "nicoco007 GH Packages" --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
 
     - name: Build Debug
       run: dotnet build ${{ github.workspace }}\BeatSaberMarkupLanguage\BeatSaberMarkupLanguage.csproj -c Debug -p:BeatSaberDir=${{ runner.temp }}\BeatSaberBindings

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nicoco007 GH Packages" value="https://nuget.pkg.github.com/nicoco007/index.json" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
To make it easier for others to see that an additional nuget feed is required, it's possible to create a NuGet.Config feed, which is also automagically picked up. Most IDEs will also request the credentials directly, if such a file is present.