### PR TITLE
Add scale setting to RectTransform handler to allow setting the scale

### DIFF
--- a/BeatSaberMarkupLanguage/TypeHandlers/RectTransformHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/RectTransformHandler.cs
@@ -24,6 +24,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             { "hoverHint", new[] { "hover-hint" } },
             { "hoverHintKey", new[] { "hover-hint-key" } },
             { "active", new[] { "active" } },
+            { "localScale", new[] { "local-scale", "scale", "size" } },
         };
 
         public override Dictionary<string, Action<RectTransform, string>> Setters => new()
@@ -41,6 +42,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             { "hoverHint", new Action<RectTransform, string>(AddHoverHint) },
             { "hoverHintKey", new Action<RectTransform, string>(AddHoverHintKey) },
             { "active", new Action<RectTransform, string>((component, value) => component.gameObject.SetActive(Parse.Bool(value))) },
+            { "localScale", new Action<RectTransform, string>((component, value) => component.localScale = Vector3.one * Parse.Float(value)) },
         };
 
         private void AddHoverHint(RectTransform rectTransform, string text)

--- a/BeatSaberMarkupLanguage/TypeHandlers/RectTransformHandler.cs
+++ b/BeatSaberMarkupLanguage/TypeHandlers/RectTransformHandler.cs
@@ -24,7 +24,7 @@ namespace BeatSaberMarkupLanguage.TypeHandlers
             { "hoverHint", new[] { "hover-hint" } },
             { "hoverHintKey", new[] { "hover-hint-key" } },
             { "active", new[] { "active" } },
-            { "localScale", new[] { "local-scale", "scale", "size" } },
+            { "localScale", new[] { "local-scale", "scale" } },
         };
 
         public override Dictionary<string, Action<RectTransform, string>> Setters => new()


### PR DESCRIPTION
Saw some comments in some mod that mentioned not being able to set this, and it would help with something I'm working on.

Could be altered to act like a `localScale *= value` rather than a direct `= one * value`

also feedback for the chosen possible names of the prop would be good, `local-scale` `scale` `size` are just things I feel would make sense for this property